### PR TITLE
BUG: non-uint-aligned arrays were counted as uint-aligned

### DIFF
--- a/numpy/core/src/common/array_assign.c
+++ b/numpy/core/src/common/array_assign.c
@@ -125,8 +125,12 @@ raw_array_is_aligned(int ndim, npy_intp *shape,
 
         return npy_is_aligned((void *)align_check, alignment);
     }
-    else {
+    else if (alignment == 1) {
         return 1;
+    }
+    else {
+        /* always return false for alignment == 0, which means unaligned */
+        return 0;
     }
 }
 

--- a/numpy/core/src/common/array_assign.h
+++ b/numpy/core/src/common/array_assign.h
@@ -88,7 +88,8 @@ broadcast_strides(int ndim, npy_intp *shape,
 /*
  * Checks whether a data pointer + set of strides refers to a raw
  * array whose elements are all aligned to a given alignment.
- * alignment should be a power of two.
+ * alignment should be a power of two, or may be the sentinel value 0 to mean
+ * unaligned, in which case false is always returned.
  */
 NPY_NO_EXPORT int
 raw_array_is_aligned(int ndim, npy_intp *shape,

--- a/numpy/core/src/multiarray/common.h
+++ b/numpy/core/src/multiarray/common.h
@@ -223,9 +223,6 @@ npy_uint_alignment(int itemsize)
         case 8:
             alignment = _ALIGN(npy_uint64);
             break;
-        case 12:
-            alignment = _ALIGN(npy_longdouble);
-            break;
         case 16:
             /*
              * 16 byte types are copied using 2 uint64 assignments.


### PR DESCRIPTION
Hi Matti. I think this is the correct fix: `raw_array_is_aligned` should return false if the queried alignment is the dummy value `0` returned by `npy_uint_alignment`.