### PR TITLE
MAINT: Simplify return types

### DIFF
--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -368,26 +368,11 @@ cdef class RandomGenerator:
                 [ True,  True]]])
 
         """
-        cdef np.npy_intp n
-        cdef np.ndarray randoms
-        cdef int64_t *randoms_data
+        return self.randint(0, np.iinfo(np.int).max + 1, dtype=np.int, size=size)
 
-        if size is None:
-            with self.lock:
-                return random_positive_int(self._brng)
-
-        randoms = <np.ndarray>np.empty(size, dtype=np.int64)
-        randoms_data = <int64_t*>np.PyArray_DATA(randoms)
-        n = np.PyArray_SIZE(randoms)
-
-        for i in range(n):
-            with self.lock, nogil:
-                randoms_data[i] = random_positive_int(self._brng)
-        return randoms
-
-    def randint(self, low, high=None, size=None, dtype=int, use_masked=True):
+    def randint(self, low, high=None, size=None, dtype=np.int64, use_masked=True):
         """
-        randint(low, high=None, size=None, dtype='l', use_masked=True)
+        randint(low, high=None, size=None, dtype='int64', use_masked=True)
 
         Return random integers from `low` (inclusive) to `high` (exclusive).
 
@@ -661,9 +646,9 @@ cdef class RandomGenerator:
                 cdf /= cdf[-1]
                 uniform_samples = self.random_sample(shape)
                 idx = cdf.searchsorted(uniform_samples, side='right')
-                idx = np.array(idx, copy=False)  # searchsorted returns a scalar
+                idx = np.array(idx, copy=False, dtype=np.int64)  # searchsorted returns a scalar
             else:
-                idx = self.randint(0, pop_size, size=shape)
+                idx = self.randint(0, pop_size, size=shape, dtype=np.int64)
         else:
             if size > pop_size:
                 raise ValueError("Cannot take a larger sample than "
@@ -692,7 +677,7 @@ cdef class RandomGenerator:
                     n_uniq += new.size
                 idx = found
             else:
-                idx = self.permutation(pop_size)[:size]
+                idx = (self.permutation(pop_size)[:size]).astype(np.int64)
                 if shape is not None:
                     idx.shape = shape
 

--- a/numpy/random/src/distributions/distributions.c
+++ b/numpy/random/src/distributions/distributions.c
@@ -1070,7 +1070,7 @@ int64_t random_zipf(brng_t *brng_state, double a) {
 
     T = pow(1.0 + 1.0 / X, am1);
     if (V * X * (T - 1.0) / (b - 1.0) <= T / b) {
-      return (long)X;
+      return (int64_t)X;
     }
   }
 }

--- a/numpy/random/tests/test_against_numpy.py
+++ b/numpy/random/tests/test_against_numpy.py
@@ -183,6 +183,7 @@ class TestAgainstNumPy(object):
                         self.rs.standard_exponential)
         self._is_state_common_legacy()
 
+    @pytest.mark.xfail(reason='Stream broken for simplicity')
     def test_tomaxint(self):
         self._set_common_state()
         self._is_state_common()

--- a/numpy/random/tests/test_against_numpy.py
+++ b/numpy/random/tests/test_against_numpy.py
@@ -328,6 +328,7 @@ class TestAgainstNumPy(object):
                      g(100, np.array(p), size=(7, 23)))
         self._is_state_common()
 
+    @pytest.mark.xfail(reason='Stream broken for performance')
     def test_choice(self):
         self._set_common_state()
         self._is_state_common()

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -639,6 +639,18 @@ class TestRandomDist(object):
         p = [None, None, None]
         assert_raises(ValueError, random.choice, a, p=p)
 
+    def test_choice_return_type(self):
+        # gh 9867
+        p = np.ones(4) / 4.
+        actual = random.choice(4, 2)
+        assert actual.dtype == np.int64
+        actual = random.choice(4, 2, replace=False)
+        assert actual.dtype == np.int64
+        actual = random.choice(4, 2, p=p)
+        assert actual.dtype == np.int64
+        actual = random.choice(4, 2, p=p, replace=False)
+        assert actual.dtype == np.int64
+
     def test_bytes(self):
         random.brng.seed(self.seed)
         actual = random.bytes(10)

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -542,25 +542,25 @@ class TestRandomDist(object):
     def test_choice_uniform_replace(self):
         random.brng.seed(self.seed)
         actual = random.choice(4, 4)
-        desired = np.array([2, 3, 2, 3])
+        desired = np.array([2, 3, 2, 3], dtype=np.int64)
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_replace(self):
         random.brng.seed(self.seed)
         actual = random.choice(4, 4, p=[0.4, 0.4, 0.1, 0.1])
-        desired = np.array([1, 1, 2, 2])
+        desired = np.array([1, 1, 2, 2], dtype=np.int64)
         assert_array_equal(actual, desired)
 
     def test_choice_uniform_noreplace(self):
         random.brng.seed(self.seed)
         actual = random.choice(4, 3, replace=False)
-        desired = np.array([0, 1, 3])
+        desired = np.array([0, 2, 3], dtype=np.int64)
         assert_array_equal(actual, desired)
 
     def test_choice_nonuniform_noreplace(self):
         random.brng.seed(self.seed)
         actual = random.choice(4, 3, replace=False, p=[0.1, 0.3, 0.5, 0.1])
-        desired = np.array([2, 3, 1])
+        desired = np.array([2, 3, 1], dtype=np.int64)
         assert_array_equal(actual, desired)
 
     def test_choice_noninteger(self):
@@ -569,11 +569,22 @@ class TestRandomDist(object):
         desired = np.array(['c', 'd', 'c', 'd'])
         assert_array_equal(actual, desired)
 
+    def test_choice_multidimensional_default_axis(self):
+        random.brng.seed(self.seed)
+        actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 3)
+        desired = np.array([[4, 5], [6, 7], [4, 5]])
+        assert_array_equal(actual, desired)
+
+    def test_choice_multidimensional_custom_axis(self):
+        random.brng.seed(self.seed)
+        actual = random.choice([[0, 1], [2, 3], [4, 5], [6, 7]], 1, axis=1)
+        desired = np.array([[0], [2], [4], [6]])
+        assert_array_equal(actual, desired)
+
     def test_choice_exceptions(self):
         sample = random.choice
         assert_raises(ValueError, sample, -1, 3)
         assert_raises(ValueError, sample, 3., 3)
-        assert_raises(ValueError, sample, [[1, 2], [3, 4]], 3)
         assert_raises(ValueError, sample, [], 3)
         assert_raises(ValueError, sample, [1, 2, 3, 4], 3,
                       p=[[0.25, 0.25], [0.25, 0.25]])
@@ -650,6 +661,17 @@ class TestRandomDist(object):
         assert actual.dtype == np.int64
         actual = random.choice(4, 2, p=p, replace=False)
         assert actual.dtype == np.int64
+
+    def test_choice_large_sample(self):
+        import hashlib
+
+        choice_hash = '6395868be877d27518c832213c17977c'
+        random.brng.seed(self.seed)
+        actual = random.choice(10000, 5000, replace=False)
+        if sys.byteorder != 'little':
+            actual = actual.byteswap()
+        res = hashlib.md5(actual.view(np.int8)).hexdigest()
+        assert_(choice_hash == res)
 
     def test_bytes(self):
         random.brng.seed(self.seed)


### PR DESCRIPTION
Standardize returns types for Windows and 32-bit platforms on int64
in choice and randint (default).
Refactor tomaxint to call randint since stream preservation in generator is not a priority.

`tomaxint` should probably be cut since it is just a trivial wrapper around `randint`, but might need more input.  This function is hard to find and I suspect some vestigial API. 
