### PR TITLE
BUG: Cast high to Python int to avoid overflow

### DIFF
--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -1130,7 +1130,7 @@ cdef class RandomState:
                            "instead".format(low=low, high=high)),
                           DeprecationWarning)
 
-        return self.randint(low, high + 1, size=size, dtype='l')
+        return self.randint(low, int(high) + 1, size=size, dtype='l')
 
     # Complicated, continuous distributions:
     def standard_normal(self, size=None):

--- a/numpy/random/tests/test_randomstate.py
+++ b/numpy/random/tests/test_randomstate.py
@@ -436,6 +436,14 @@ class TestRandomDist(object):
 
         desired = np.iinfo('l').max
         assert_equal(actual, desired)
+        with suppress_warnings() as sup:
+            w = sup.record(DeprecationWarning)
+            typer = np.dtype('l').type
+            actual = random.random_integers(typer(np.iinfo('l').max),
+                                            typer(np.iinfo('l').max))
+            assert_(len(w) == 1)
+        assert_equal(actual, desired)
+
 
     def test_random_integers_deprecated(self):
         with warnings.catch_warnings():


### PR DESCRIPTION
Bug in random_integers discovered in numpy/numpy#13164