### PR TITLE
PERF: Reorder header for philox

### DIFF
--- a/numpy/random/src/pcg64/pcg64.h
+++ b/numpy/random/src/pcg64/pcg64.h
@@ -62,7 +62,7 @@
 extern "C" {
 #endif
 
-#if __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
+#ifdef __SIZEOF_INT128__ && !defined(PCG_FORCE_EMULATED_128BIT_MATH)
 typedef __uint128_t pcg128_t;
 #define PCG_128BIT_CONSTANT(high, low) (((pcg128_t)(high) << 64) + low)
 #else

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -26,7 +26,7 @@ _philox4x64bumpkey(struct r123array2x64 key) {
 }
 
 /* Prefer uint128 if available: GCC, clang, ICC */
-#if __SIZEOF_INT128__
+#ifdef __SIZEOF_INT128__
 static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
   __uint128_t product = ((__uint128_t)a) * ((__uint128_t)b);
   *hip = product >> 64;
@@ -35,7 +35,7 @@ static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
 #else
 #ifdef _WIN32
 #include <intrin.h>
-#if _WIN64 && _M_AMD64
+#ifdef _WIN64 && _M_AMD64
 #pragma intrinsic(_umul128)
 #else
 #pragma intrinsic(__emulu)

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -25,10 +25,17 @@ _philox4x64bumpkey(struct r123array2x64 key) {
   return key;
 }
 
+/* Prefer uint128 if available: GCC, clang, ICC */
+#if __SIZEOF_INT128__
+static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
+  __uint128_t product = ((__uint128_t)a) * ((__uint128_t)b);
+  *hip = product >> 64;
+  return (uint64_t)product;
+}
+#else
 #ifdef _WIN32
 #include <intrin.h>
-/* TODO: This isn't correct for many platforms */
-#ifdef _WIN64
+#if _WIN64 && _M_AMD64
 #pragma intrinsic(_umul128)
 #else
 #pragma intrinsic(__emulu)
@@ -57,13 +64,6 @@ static NPY_INLINE uint64_t _umul128(uint64_t a, uint64_t b, uint64_t *high) {
 #endif
 static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
   return _umul128(a, b, hip);
-}
-#else
-#if __SIZEOF_INT128__
-static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
-  __uint128_t product = ((__uint128_t)a) * ((__uint128_t)b);
-  *hip = product >> 64;
-  return (uint64_t)product;
 }
 #else
 static NPY_INLINE uint64_t _umul128(uint64_t a, uint64_t b, uint64_t *high) {

--- a/numpy/random/src/philox/philox.h
+++ b/numpy/random/src/philox/philox.h
@@ -35,7 +35,7 @@ static NPY_INLINE uint64_t mulhilo64(uint64_t a, uint64_t b, uint64_t *hip) {
 #else
 #ifdef _WIN32
 #include <intrin.h>
-#ifdef _WIN64 && _M_AMD64
+#if defined(_WIN64) && defined(_M_AMD64)
 #pragma intrinsic(_umul128)
 #else
 #pragma intrinsic(__emulu)


### PR DESCRIPTION
Reorder header so that support uint128 is always used if available, irrespective of platform

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
