### PR TITLE
ENH: Warn about non-native byte order

### DIFF
--- a/numpy/random/generator.pyx
+++ b/numpy/random/generator.pyx
@@ -429,9 +429,16 @@ cdef class Generator:
             high = low
             low = 0
 
-        key = np.dtype(dtype).name
+        dt = np.dtype(dtype)
+        key = dt.name
         if key not in _integers_types:
             raise TypeError('Unsupported dtype "%s" for integers' % key)
+        if dt.byteorder != '=' and dt.byteorder != '|':
+            import warnings
+            warnings.warn('Byteorder is not supported. If you require '
+                          'platform-independent byteorder, call byteswap when '
+                          'required.\n\nIn future version, specifying '
+                          'byteorder will raise a ValueError', FutureWarning)
 
         # Implementation detail: the old API used a masked method to generate
         # bounded uniform integers. Lemire's method is preferrable since it is

--- a/numpy/random/mtrand.pyx
+++ b/numpy/random/mtrand.pyx
@@ -606,9 +606,16 @@ cdef class RandomState:
             high = low
             low = 0
 
-        key = np.dtype(dtype).name
+        dt = np.dtype(dtype)
+        key = dt.name
         if key not in _integers_types:
             raise TypeError('Unsupported dtype "%s" for randint' % key)
+        if dt.byteorder != '=' and dt.byteorder != '|':
+            import warnings
+            warnings.warn('Byteorder is not supported. If you require '
+                          'platform-independent byteorder, call byteswap when '
+                          'required.\n\nIn future version, specifying '
+                          'byteorder will raise a ValueError', FutureWarning)
 
         # Implementation detail: the use a masked method to generate
         # bounded uniform integers. Lemire's method is preferrable since it is

--- a/numpy/random/tests/test_generator_mt19937.py
+++ b/numpy/random/tests/test_generator_mt19937.py
@@ -467,6 +467,10 @@ class TestIntegers(object):
             assert_equal(random.integers(0, -10, size=0).shape, (0,))
             assert_equal(random.integers(10, 10, size=0).shape, (0,))
 
+    def test_warns_byteorder(self):
+        other_byteord_dt = '<i4' if sys.byteorder == 'big' else '>i4'
+        with pytest.warns(FutureWarning):
+            random.integers(0, 200, size=10, dtype=other_byteord_dt)
 
 class TestRandomDist(object):
     # Make sure the random distribution returns the correct value for a

--- a/numpy/random/tests/test_randomstate_regression.py
+++ b/numpy/random/tests/test_randomstate_regression.py
@@ -1,4 +1,7 @@
 import sys
+
+import pytest
+
 from numpy.testing import (
     assert_, assert_array_equal, assert_raises,
     )
@@ -155,3 +158,9 @@ class TestRegression(object):
         perm = random.permutation(m)
         assert_array_equal(perm, np.array([2, 1, 4, 0, 3]))
         assert_array_equal(m.__array__(), np.arange(5))
+
+    def test_warns_byteorder(self):
+        # GH 13159
+        other_byteord_dt = '<i4' if sys.byteorder == 'big' else '>i4'
+        with pytest.warns(FutureWarning):
+            random.randint(0, 200, size=10, dtype=other_byteord_dt)


### PR DESCRIPTION
Warn that non-native byte order is not supported in randint and integers

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message
-->
