### PR TITLE
MAINT: ship common.pxd, bit_generator.pxd in the wheel

### DIFF
--- a/numpy/random/bit_generator.pxd
+++ b/numpy/random/bit_generator.pxd
@@ -1,5 +1,5 @@
 
-from .distributions cimport bitgen_t
+from .common cimport bitgen_t
 cimport numpy as np
 
 cdef class BitGenerator():

--- a/numpy/random/common.pxd
+++ b/numpy/random/common.pxd
@@ -5,7 +5,16 @@ from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
                           uintptr_t)
 from libc.math cimport sqrt
 
-from .distributions cimport bitgen_t 
+cdef extern from "src/bitgen.h":
+    struct bitgen:
+        void *state
+        uint64_t (*next_uint64)(void *st) nogil
+        uint32_t (*next_uint32)(void *st) nogil
+        double (*next_double)(void *st) nogil
+        uint64_t (*next_raw)(void *st) nogil
+
+    ctypedef bitgen bitgen_t
+
 import numpy as np
 cimport numpy as np
 

--- a/numpy/random/distributions.pxd
+++ b/numpy/random/distributions.pxd
@@ -1,7 +1,7 @@
 #cython: language_level=3
 
-from libc.stdint cimport (uint8_t, uint16_t, uint32_t, uint64_t,
-                          int32_t, int64_t)
+from .common cimport (uint8_t, uint16_t, uint32_t, uint64_t,
+                          int32_t, int64_t, bitgen_t)
 import numpy as np
 cimport numpy as np
 
@@ -27,15 +27,6 @@ cdef extern from "src/distributions/distributions.h":
         double p4
 
     ctypedef s_binomial_t binomial_t
-
-    struct bitgen:
-        void *state
-        uint64_t (*next_uint64)(void *st) nogil
-        uint32_t (*next_uint32)(void *st) nogil
-        double (*next_double)(void *st) nogil
-        uint64_t (*next_raw)(void *st) nogil
-
-    ctypedef bitgen bitgen_t
 
     double random_double(bitgen_t *bitgen_state) nogil
     void random_double_fill(bitgen_t* bitgen_state, np.npy_intp cnt, double *out) nogil

--- a/numpy/random/setup.py
+++ b/numpy/random/setup.py
@@ -34,6 +34,8 @@ def configuration(parent_package='', top_path=None):
 
     defs.append(('NPY_NO_DEPRECATED_API', 0))
     config.add_data_dir('tests')
+    config.add_data_files('common.pxd')
+    config.add_data_files('bit_generator.pxd')
 
     EXTRA_LINK_ARGS = []
     # Math lib

--- a/numpy/random/src/bitgen.h
+++ b/numpy/random/src/bitgen.h
@@ -1,0 +1,18 @@
+#ifndef _RANDOM_BITGEN_H
+#define _RANDOM_BITGEN_H
+
+#pragma once
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct bitgen {
+  void *state;
+  uint64_t (*next_uint64)(void *st);
+  uint32_t (*next_uint32)(void *st);
+  double (*next_double)(void *st);
+  uint64_t (*next_raw)(void *st);
+} bitgen_t;
+
+
+#endif

--- a/numpy/random/src/distributions/distributions.h
+++ b/numpy/random/src/distributions/distributions.h
@@ -9,6 +9,7 @@
 #include "Python.h"
 #include "numpy/npy_common.h"
 #include "numpy/npy_math.h"
+#include "src/bitgen.h"
 
 /*
  * RAND_INT_TYPE is used to share integer generators with RandomState which
@@ -58,14 +59,6 @@ typedef struct s_binomial_t {
   double p3;
   double p4;
 } binomial_t;
-
-typedef struct bitgen {
-  void *state;
-  uint64_t (*next_uint64)(void *st);
-  uint32_t (*next_uint32)(void *st);
-  double (*next_double)(void *st);
-  uint64_t (*next_raw)(void *st);
-} bitgen_t;
 
 /* Inline generators for internal use */
 static NPY_INLINE uint32_t next_uint32(bitgen_t *bitgen_state) {


### PR DESCRIPTION
In order to use `bit_generator.pxd` to create additional BitGenerators, it needs `bitgen_t`. This PR moves things around so the declaration of `bitgen_t` is in a separate header file and also adds the `pxd` files to the package, so the numpy/bitgenerators can build