### PR TITLE
Allow closure-like definition of the data mem routines

### DIFF
--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -61,20 +61,20 @@ reallocate or free the data memory of the instance.
 
         typedef struct {
             char name[128];  /* multiple of 64 to keep the struct aligned */
-            PyDataMem_AllocFunc *alloc;
-            PyDataMem_ZeroedAllocFunc *zeroed_alloc;
-            PyDataMem_FreeFunc *free;
-            PyDataMem_ReallocFunc *realloc;
+            PyDataMemAllocator allocator;
         } PyDataMem_Handler;
 
-    where the function's signatures are
+    where the allocator structure is:
 
     .. code-block:: c
 
-        typedef void *(PyDataMem_AllocFunc)(size_t size);
-        typedef void *(PyDataMem_ZeroedAllocFunc)(size_t nelems, size_t elsize);
-        typedef void (PyDataMem_FreeFunc)(void *ptr, size_t size);
-        typedef void *(PyDataMem_ReallocFunc)(void *ptr, size_t size);
+        typedef struct {
+            void *ctx;
+            void* (*malloc) (void *ctx, size_t size);
+            void* (*calloc) (void *ctx, size_t nelem, size_t elsize);
+            void* (*realloc) (void *ctx, void *ptr, size_t new_size);
+            void (*free) (void *ctx, void *ptr, size_t size);
+        } PyDataMemAllocator;
 
 .. c:function:: const PyDataMem_Handler * PyDataMem_SetHandler(PyDataMem_Handler *handler)
 

--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -68,6 +68,7 @@ reallocate or free the data memory of the instance.
 
     .. code-block:: c
 
+        /* The declaration of free differs from PyMemAllocatorEx */ 
         typedef struct {
             void *ctx;
             void* (*malloc) (void *ctx, size_t size);
@@ -119,4 +120,3 @@ For an example of setting up and using the PyDataMem_Handler, see the test in
     operations that might cause new allocation events (such as the
     creation/destruction numpy objects, or creating/destroying Python
     objects which might cause a gc)
-

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -667,6 +667,7 @@ typedef struct _arr_descr {
 /*
  * Memory handler structure for array data.
  */
+/* The declaration of free differs from PyMemAllocatorEx */
 typedef struct {
     void *ctx;
     void* (*malloc) (void *ctx, size_t size);

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -667,17 +667,17 @@ typedef struct _arr_descr {
 /*
  * Memory handler structure for array data.
  */
-typedef void *(PyDataMem_AllocFunc)(size_t size);
-typedef void *(PyDataMem_ZeroedAllocFunc)(size_t nelems, size_t elsize);
-typedef void (PyDataMem_FreeFunc)(void *ptr, size_t size);
-typedef void *(PyDataMem_ReallocFunc)(void *ptr, size_t size);
+typedef struct {
+    void *ctx;
+    void* (*malloc) (void *ctx, size_t size);
+    void* (*calloc) (void *ctx, size_t nelem, size_t elsize);
+    void* (*realloc) (void *ctx, void *ptr, size_t new_size);
+    void (*free) (void *ctx, void *ptr, size_t size);
+} PyDataMemAllocator;
 
 typedef struct {
     char name[128];  /* multiple of 64 to keep the struct aligned */
-    PyDataMem_AllocFunc *alloc;
-    PyDataMem_ZeroedAllocFunc *zeroed_alloc;
-    PyDataMem_FreeFunc *free;
-    PyDataMem_ReallocFunc *realloc;
+    PyDataMemAllocator allocator;
 } PyDataMem_Handler;
 
 
@@ -732,7 +732,7 @@ typedef struct tagPyArrayObject_fields {
     PyObject *weakreflist;
     void *_buffer_info;  /* private buffer info, tagged to allow warning */
     /*
-     * For alloc/malloc/realloc/free/memcpy per object
+     * For malloc/calloc/realloc/free per object
      */
     PyDataMem_Handler *mem_handler;
 } PyArrayObject_fields;

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -329,11 +329,11 @@ PyDataMem_RENEW(void *ptr, size_t size)
 PyDataMem_Handler default_handler = {
     "default_allocator",
     {
-        NULL,                 /* ctx */
-        npy_alloc_cache,      /* malloc */
-        npy_alloc_cache_zero, /* calloc */
-        PyDataMem_RENEW,      /* realloc */
-        npy_free_cache        /* free */
+        NULL,                                                     /* ctx */
+        (void *(*)(void *, size_t)) npy_alloc_cache,              /* malloc */
+        (void *(*)(void *, size_t, size_t)) npy_alloc_cache_zero, /* calloc */
+        (void *(*)(void *, void *, size_t)) PyDataMem_RENEW,      /* realloc */
+        (void (*)(void *, void *, size_t)) npy_free_cache         /* free */
     }
 };
 
@@ -348,7 +348,7 @@ PyDataMem_UserNEW(size_t size, PyDataMemAllocator allocator)
 {
     void *result;
 
-    if (allocator.malloc == npy_alloc_cache) {
+    if ((void *) allocator.malloc == (void *) npy_alloc_cache) {
         // All the logic below is conditionally handled by npy_alloc_cache
         return npy_alloc_cache(size);
     }
@@ -371,7 +371,7 @@ NPY_NO_EXPORT void *
 PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator)
 {
     void *result;
-    if (allocator.calloc == npy_alloc_cache_zero) {
+    if ((void *) allocator.calloc == (void *) npy_alloc_cache_zero) {
         // All the logic below is conditionally handled by npy_alloc_cache_zero
         return npy_alloc_cache_zero(nmemb, size);
     }
@@ -393,7 +393,7 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator
 NPY_NO_EXPORT void
 PyDataMem_UserFREE(void *ptr, size_t size, PyDataMemAllocator allocator)
 {
-    if (allocator.free == npy_free_cache) {
+    if ((void *) allocator.free == (void *) npy_free_cache) {
         // All the logic below is conditionally handled by npy_free_cache
         npy_free_cache(ptr, size);
         return;
@@ -414,7 +414,7 @@ PyDataMem_UserFREE(void *ptr, size_t size, PyDataMemAllocator allocator)
 NPY_NO_EXPORT void *
 PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMemAllocator allocator)
 {
-    if (allocator.realloc == PyDataMem_RENEW) {
+    if ((void *) allocator.realloc == (void *) PyDataMem_RENEW) {
         // All the logic below is conditionally handled by PyDataMem_RENEW
         return PyDataMem_RENEW(ptr, size);
     }

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -10,16 +10,16 @@ NPY_NO_EXPORT PyObject *
 _set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW(npy_uintp sz, PyDataMem_AllocFunc *alloc);
+PyDataMem_UserNEW(npy_uintp sz, PyDataMemAllocator allocator);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMem_ZeroedAllocFunc *zalloc);
+PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator);
 
 NPY_NO_EXPORT void
-PyDataMem_UserFREE(void * p, npy_uintp sd, PyDataMem_FreeFunc *func);
+PyDataMem_UserFREE(void * p, npy_uintp sd, PyDataMemAllocator allocator);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMem_ReallocFunc *func);
+PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMemAllocator allocator);
 
 NPY_NO_EXPORT void *
 npy_alloc_cache_dim(npy_uintp sz);
@@ -39,8 +39,8 @@ npy_free_cache_dim_array(PyArrayObject * arr)
     npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
 }
 
-extern PyDataMem_Handler *current_allocator;
-extern PyDataMem_Handler default_allocator;
+extern PyDataMem_Handler *current_handler;
+extern PyDataMem_Handler default_handler;
 
 NPY_NO_EXPORT PyObject *
 get_handler_name(PyObject *NPY_UNUSED(self), PyObject *obj);

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -500,7 +500,7 @@ array_dealloc(PyArrayObject *self)
         if (nbytes == 0) {
             nbytes = fa->descr->elsize ? fa->descr->elsize : 1;
         }
-        PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler->free);
+        PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler->allocator);
     }
 
     /* must match allocation in PyArray_NewFromDescr */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3088,7 +3088,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         if (swap || new->alignment > 1) {
             if (swap || !npy_is_aligned(nip1, new->alignment)) {
                 /* create buffer and copy */
-                nip1 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->alloc);
+                nip1 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->allocator);
                 if (nip1 == NULL) {
                     goto finish;
                 }
@@ -3098,11 +3098,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
             }
             if (swap || !npy_is_aligned(nip2, new->alignment)) {
                 /* create buffer and copy */
-                nip2 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->alloc);
+                nip2 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->allocator);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
                         PyDataMem_UserFREE(nip1, new->elsize,
-                                           PyArray_HANDLER(ap)->free);
+                                           PyArray_HANDLER(ap)->allocator);
                     }
                     goto finish;
                 }
@@ -3114,10 +3114,10 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         res = new->f->compare(nip1, nip2, dummy);
         if (swap || new->alignment > 1) {
             if (nip1 != ip1 + offset) {
-                PyDataMem_UserFREE(nip1, new->elsize, PyArray_HANDLER(ap)->free);
+                PyDataMem_UserFREE(nip1, new->elsize, PyArray_HANDLER(ap)->allocator);
             }
             if (nip2 != ip2 + offset) {
-                PyDataMem_UserFREE(nip2, new->elsize, PyArray_HANDLER(ap)->free);
+                PyDataMem_UserFREE(nip2, new->elsize, PyArray_HANDLER(ap)->allocator);
             }
         }
         if (res != 0) {

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -394,7 +394,7 @@ array_data_set(PyArrayObject *self, PyObject *op)
             nbytes = dtype->elsize ? dtype->elsize : 1;
         }
         PyDataMem_UserFREE(PyArray_DATA(self), nbytes,
-                           PyArray_HANDLER(self)->free);
+                           PyArray_HANDLER(self)->allocator);
     }
     if (PyArray_BASE(self)) {
         if ((PyArray_FLAGS(self) & NPY_ARRAY_WRITEBACKIFCOPY) ||

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -970,7 +970,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     size = it->size;
 
     if (needcopy) {
-        buffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->alloc);
+        buffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->allocator);
         if (buffer == NULL) {
             ret = -1;
             goto fail;
@@ -1054,7 +1054,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
-    PyDataMem_UserFREE(buffer, N * elsize, PyArray_HANDLER(op)->free);
+    PyDataMem_UserFREE(buffer, N * elsize, PyArray_HANDLER(op)->allocator);
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
         PyErr_NoMemory();
@@ -1116,7 +1116,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     size = it->size;
 
     if (needcopy) {
-        valbuffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->alloc);
+        valbuffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->allocator);
         if (valbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1125,7 +1125,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
     if (needidxbuffer) {
         idxbuffer = (npy_intp *)PyDataMem_UserNEW(N * sizeof(npy_intp),
-                                                  PyArray_HANDLER(op)->alloc);
+                                                  PyArray_HANDLER(op)->allocator);
         if (idxbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1214,8 +1214,8 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
-    PyDataMem_UserFREE(valbuffer, N * elsize, PyArray_HANDLER(op)->free);
-    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), PyArray_HANDLER(op)->free);
+    PyDataMem_UserFREE(valbuffer, N * elsize, PyArray_HANDLER(op)->allocator);
+    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), PyArray_HANDLER(op)->allocator);
     if (ret < 0) {
         if (!PyErr_Occurred()) {
             /* Out of memory during sorting or buffer creation */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2051,7 +2051,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
          * line 820
          */
         PyDataMem_UserFREE(PyArray_DATA(self), n_tofree,
-                           PyArray_HANDLER(self)->free);
+                           PyArray_HANDLER(self)->allocator);
         PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
     }
     Py_XDECREF(PyArray_BASE(self));
@@ -2095,7 +2095,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 Py_DECREF(rawdata);
                 Py_RETURN_NONE;
             }
-            fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->alloc);
+            fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
             if (PyArray_DATA(self) == NULL) {
                 Py_DECREF(rawdata);
                 return PyErr_NoMemory();
@@ -2145,7 +2145,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         if (num == 0 || elsize == 0) {
             Py_RETURN_NONE;
         }
-        fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->alloc);
+        fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
         if (PyArray_DATA(self) == NULL) {
             return PyErr_NoMemory();
         }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -122,7 +122,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         /* Reallocate space if needed - allocating 0 is forbidden */
         new_data = PyDataMem_UserRENEW(PyArray_DATA(self),
                                        newnbytes == 0 ? elsize : newnbytes,
-                                       PyArray_HANDLER(self)->realloc);
+                                       PyArray_HANDLER(self)->allocator);
         if (new_data == NULL) {
             PyErr_SetString(PyExc_MemoryError,
                     "cannot allocate memory for array");


### PR DESCRIPTION
Encapsulated a `PyMemAllocatorEx`-like struct in `PyDataMem_Handler` structure.

The reference `PyMemAllocatorEx` structure has a different function signature for `free` (w/o `size_t size`).

Knowing the `size` (during `free`) could be particularly useful when implementing `mmap`/`munmap`-based allocators or pooled allocators backed by memory arenas. If this is not the case here, we could stick with the original `PyMemAllocatorEx` definition.

The `mem_policy` test is also modified to make fair use of the new `ctx` argument.