### PR TITLE
Always allocate new arrays using the current_handler 

### DIFF
--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -64,7 +64,7 @@ reallocate or free the data memory of the instance.
             PyDataMemAllocator allocator;
         } PyDataMem_Handler;
 
-    where the allocator structure is:
+    where the allocator structure is
 
     .. code-block:: c
 
@@ -88,7 +88,9 @@ reallocate or free the data memory of the instance.
 .. c:function:: const char * PyDataMem_GetHandlerName(PyArrayObject *obj)
 
    Return the const char name of the `PyDataMem_Handler` used by the
-   ``PyArrayObject``. If ``NULL``, return the name of the current global policy
+   ``PyArrayObject`` or its base. If neither the ``PyArrayObject`` owns its own
+   data nor its base is a ``PyArrayObject`` which owns its own data return an
+   empty string. If ``NULL``, return the name of the current global policy
    that will be used to allocate data for the next ``PyArrayObject``.
 
 For an example of setting up and using the PyDataMem_Handler, see the test in

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3088,7 +3088,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         if (swap || new->alignment > 1) {
             if (swap || !npy_is_aligned(nip1, new->alignment)) {
                 /* create buffer and copy */
-                nip1 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->allocator);
+                nip1 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
                 if (nip1 == NULL) {
                     goto finish;
                 }
@@ -3098,11 +3098,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
             }
             if (swap || !npy_is_aligned(nip2, new->alignment)) {
                 /* create buffer and copy */
-                nip2 = PyDataMem_UserNEW(new->elsize, PyArray_HANDLER(ap)->allocator);
+                nip2 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
                         PyDataMem_UserFREE(nip1, new->elsize,
-                                           PyArray_HANDLER(ap)->allocator);
+                                           current_handler->allocator);
                     }
                     goto finish;
                 }
@@ -3114,10 +3114,10 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         res = new->f->compare(nip1, nip2, dummy);
         if (swap || new->alignment > 1) {
             if (nip1 != ip1 + offset) {
-                PyDataMem_UserFREE(nip1, new->elsize, PyArray_HANDLER(ap)->allocator);
+                PyDataMem_UserFREE(nip1, new->elsize, current_handler->allocator);
             }
             if (nip2 != ip2 + offset) {
-                PyDataMem_UserFREE(nip2, new->elsize, PyArray_HANDLER(ap)->allocator);
+                PyDataMem_UserFREE(nip2, new->elsize, current_handler->allocator);
             }
         }
         if (res != 0) {

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3080,7 +3080,6 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         }
         /* Set the fields needed by compare or copyswap */
         dummy_struct.descr = new;
-        dummy_struct.mem_handler = PyArray_HANDLER(ap);
 
         swap = PyArray_ISBYTESWAPPED(dummy);
         nip1 = ip1 + offset;

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3086,7 +3086,10 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         nip2 = ip2 + offset;
         if (swap || new->alignment > 1) {
             if (swap || !npy_is_aligned(nip1, new->alignment)) {
-                /* create buffer and copy */
+                /*
+                 * create temporary buffer and copy,
+                 * always use the current handler for internal allocations
+                 */
                 nip1 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
                 if (nip1 == NULL) {
                     goto finish;
@@ -3096,10 +3099,14 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                     new->f->copyswap(nip1, NULL, swap, dummy);
             }
             if (swap || !npy_is_aligned(nip2, new->alignment)) {
-                /* create buffer and copy */
+                /*
+                 * create temporary buffer and copy,
+                 * always use the current handler for internal allocations
+                 */
                 nip2 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
+                        /* destroy temporary buffer */
                         PyDataMem_UserFREE(nip1, new->elsize,
                                            current_handler->allocator);
                     }
@@ -3113,9 +3120,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         res = new->f->compare(nip1, nip2, dummy);
         if (swap || new->alignment > 1) {
             if (nip1 != ip1 + offset) {
+                /* destroy temporary buffer */
                 PyDataMem_UserFREE(nip1, new->elsize, current_handler->allocator);
             }
             if (nip2 != ip2 + offset) {
+                /* destroy temporary buffer */
                 PyDataMem_UserFREE(nip2, new->elsize, current_handler->allocator);
             }
         }

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -806,7 +806,7 @@ PyArray_NewFromDescr_int(
 
 
     if (data == NULL) {
-        /* Store the functions in case the global hander is modified */
+        /* Store the functions in case the global handler is modified */
         fa->mem_handler = current_handler;
         /*
          * Allocate something even for zero-space arrays
@@ -837,8 +837,8 @@ PyArray_NewFromDescr_int(
         fa->flags |= NPY_ARRAY_OWNDATA;
     }
     else {
-        /* The handlers should never be called in this case, but just in case */
-        fa->mem_handler = &default_handler;
+        /* The handlers should never be called in this case */
+        fa->mem_handler = NULL;
         /*
          * If data is passed in, this object won't own it by default.
          * Caller must arrange for this to be reset if truly desired

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -970,7 +970,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     size = it->size;
 
     if (needcopy) {
-        buffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->allocator);
+        buffer = PyDataMem_UserNEW(N * elsize, current_handler->allocator);
         if (buffer == NULL) {
             ret = -1;
             goto fail;
@@ -1054,7 +1054,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
-    PyDataMem_UserFREE(buffer, N * elsize, PyArray_HANDLER(op)->allocator);
+    PyDataMem_UserFREE(buffer, N * elsize, current_handler->allocator);
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
         PyErr_NoMemory();
@@ -1116,7 +1116,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     size = it->size;
 
     if (needcopy) {
-        valbuffer = PyDataMem_UserNEW(N * elsize, PyArray_HANDLER(op)->allocator);
+        valbuffer = PyDataMem_UserNEW(N * elsize, current_handler->allocator);
         if (valbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1125,7 +1125,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
     if (needidxbuffer) {
         idxbuffer = (npy_intp *)PyDataMem_UserNEW(N * sizeof(npy_intp),
-                                                  PyArray_HANDLER(op)->allocator);
+                                                  current_handler->allocator);
         if (idxbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1214,8 +1214,8 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
-    PyDataMem_UserFREE(valbuffer, N * elsize, PyArray_HANDLER(op)->allocator);
-    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), PyArray_HANDLER(op)->allocator);
+    PyDataMem_UserFREE(valbuffer, N * elsize, current_handler->allocator);
+    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), current_handler->allocator);
     if (ret < 0) {
         if (!PyErr_Occurred()) {
             /* Out of memory during sorting or buffer creation */

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -1054,6 +1054,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
+    /* cleanup internal buffer */
     PyDataMem_UserFREE(buffer, N * elsize, current_handler->allocator);
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
@@ -1214,6 +1215,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
+    /* cleanup internal buffers */
     PyDataMem_UserFREE(valbuffer, N * elsize, current_handler->allocator);
     PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), current_handler->allocator);
     if (ret < 0) {

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2095,6 +2095,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
                 Py_DECREF(rawdata);
                 Py_RETURN_NONE;
             }
+            /* Store the functions in case the global handler is modified */
+            fa->mem_handler = current_handler;
             fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
             if (PyArray_DATA(self) == NULL) {
                 Py_DECREF(rawdata);
@@ -2132,6 +2134,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
             Py_DECREF(rawdata);
         }
         else {
+            /* The handlers should never be called in this case */
+            fa->mem_handler = NULL;
             fa->data = datastr;
             if (PyArray_SetBaseObject(self, rawdata) < 0) {
                 Py_DECREF(rawdata);
@@ -2145,6 +2149,8 @@ array_setstate(PyArrayObject *self, PyObject *args)
         if (num == 0 || elsize == 0) {
             Py_RETURN_NONE;
         }
+        /* Store the functions in case the global handler is modified */
+        fa->mem_handler = current_handler;
         fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
         if (PyArray_DATA(self) == NULL) {
             return PyErr_NoMemory();

--- a/numpy/core/tests/test_mem_policy.py
+++ b/numpy/core/tests/test_mem_policy.py
@@ -152,7 +152,7 @@ def test_new_policy(get_module):
     a = np.arange(10)
     orig_policy = get_module.test_prefix(a)
     assert get_module.set_new_policy() == orig_policy
-    b = np.arange(10)
+    b = np.arange(10).reshape((2, 5))
     assert get_module.test_prefix(b) == 'secret_data_allocator'
 
     # test array manipulation. This is slow


### PR DESCRIPTION
The proposed changes are:

1. Use the `current_handler` for every `PyDataMem_UserNEW/NEW_ZEROED` function call.

    This includes internal alloc/free operations in functions like `numpy.argsort`, but also the array re-construction during "unpickling".

    It has the following benefits:
    * If an array doesn't own its own data then it won't need a handler during its lifetime. Finding the correct handler to "inherit" has proven itself to be a difficult task (e.g. what it should be if there is also no base array available?).
    * It creates a single source of information for the allocation of new arrays, and makes it easier for the user to configure it.

    I am also pretty sure that it fixes an [inconsistency](https://github.com/mattip/numpy/blob/fb97134520ece9d3bae4be4a6facbc86a16f7aa0/numpy/core/src/multiarray/methods.c#L2135-L2140) in an "unpickling" case, in which, although the "unpickled" array doesn't own its own data, the `mem_handler` of the previous data is inherited.

2. Enhance `PyDataMem_GetHandlerName` capabilities and try to get the name of the handler that allocated the underlying memory region.

    Generally, there are three possible scenarios:
    a. An array owns its own data
    b. An array doesn't own its own data but its base is an array which owns its own data
    c. An array doesn't own its own data and has no base or its base is either not an array or an array which doesn't own its own data

    Depending on the scenario, `PyDataMem_GetHandlerName` returns:
    a. `array->mem_handler->name`
    b. `array->base->mem_handler->name`
    c. empty string

    **Notes**:
    * For `c`, I chose the empty string instead of `NULL` because in the context-local version of the `current_handler` that I am preparing the function can also fail (`PyContextVar_Get` can fail).
    * In the `get_handler_name` wrapper that empty string is translated to a `Py_None`, but this is just personal taste and we could omit it.