### PR TITLE
Make the default_handler a valid PyDataMem_Handler 

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -471,10 +471,9 @@ PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMemAllocator allocator)
 
 /*NUMPY_API
  * Sets a new allocation policy. If the input value is NULL, will reset
- * the policy to the default. Returns the previous policy, NULL if the
- * previous policy was the default. We wrap the user-provided functions
- * so they will still call the python and numpy memory management callback
- * hooks.
+ * the policy to the default. Returns the previous policy. We wrap
+ * the user-provided functions so they will still call the python
+ * and numpy memory management callback hooks.
  */
 NPY_NO_EXPORT const PyDataMem_Handler *
 PyDataMem_SetHandler(PyDataMem_Handler *handler)

--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -393,12 +393,12 @@ int uo_index=0;   /* user_override index */
 /* Wrappers for the default or any user-assigned PyDataMem_Handler */
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW(size_t size, PyDataMemAllocator allocator)
+PyDataMem_UserNEW(size_t size, const PyDataMemAllocator *allocator)
 {
     void *result;
 
     assert(size != 0);
-    result = allocator.malloc(allocator.ctx, size);
+    result = allocator->malloc(allocator->ctx, size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
         NPY_ALLOW_C_API
@@ -413,10 +413,10 @@ PyDataMem_UserNEW(size_t size, PyDataMemAllocator allocator)
 }
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator)
+PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, const PyDataMemAllocator *allocator)
 {
     void *result;
-    result = allocator.calloc(allocator.ctx, nmemb, size);
+    result = allocator->calloc(allocator->ctx, nmemb, size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
         NPY_ALLOW_C_API
@@ -431,10 +431,10 @@ PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator
 }
 
 NPY_NO_EXPORT void
-PyDataMem_UserFREE(void *ptr, size_t size, PyDataMemAllocator allocator)
+PyDataMem_UserFREE(void *ptr, size_t size, const PyDataMemAllocator *allocator)
 {
     PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
-    allocator.free(allocator.ctx, ptr, size);
+    allocator->free(allocator->ctx, ptr, size);
     if (_PyDataMem_eventhook != NULL) {
         NPY_ALLOW_C_API_DEF
         NPY_ALLOW_C_API
@@ -447,12 +447,12 @@ PyDataMem_UserFREE(void *ptr, size_t size, PyDataMemAllocator allocator)
 }
 
 NPY_NO_EXPORT void *
-PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMemAllocator allocator)
+PyDataMem_UserRENEW(void *ptr, size_t size, const PyDataMemAllocator *allocator)
 {
     void *result;
 
     assert(size != 0);
-    result = allocator.realloc(allocator.ctx, ptr, size);
+    result = allocator->realloc(allocator->ctx, ptr, size);
     if (result != ptr) {
         PyTraceMalloc_Untrack(NPY_TRACE_DOMAIN, (npy_uintp)ptr);
     }

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -10,16 +10,16 @@ NPY_NO_EXPORT PyObject *
 _set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW(npy_uintp sz, PyDataMemAllocator allocator);
+PyDataMem_UserNEW(npy_uintp sz, const PyDataMemAllocator *allocator);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyDataMemAllocator allocator);
+PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, const PyDataMemAllocator *allocator);
 
 NPY_NO_EXPORT void
-PyDataMem_UserFREE(void * p, npy_uintp sd, PyDataMemAllocator allocator);
+PyDataMem_UserFREE(void * p, npy_uintp sd, const PyDataMemAllocator *allocator);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserRENEW(void *ptr, size_t size, PyDataMemAllocator allocator);
+PyDataMem_UserRENEW(void *ptr, size_t size, const PyDataMemAllocator *allocator);
 
 NPY_NO_EXPORT void *
 npy_alloc_cache_dim(npy_uintp sz);

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -501,7 +501,7 @@ array_dealloc(PyArrayObject *self)
         if (nbytes == 0) {
             nbytes = fa->descr->elsize ? fa->descr->elsize : 1;
         }
-        PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler->allocator);
+        PyDataMem_UserFREE(fa->data, nbytes, &fa->mem_handler->allocator);
     }
 
     /* must match allocation in PyArray_NewFromDescr */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3090,7 +3090,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip1 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
+                nip1 = PyDataMem_UserNEW(new->elsize, &current_handler->allocator);
                 if (nip1 == NULL) {
                     goto finish;
                 }
@@ -3103,12 +3103,12 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip2 = PyDataMem_UserNEW(new->elsize, current_handler->allocator);
+                nip2 = PyDataMem_UserNEW(new->elsize, &current_handler->allocator);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
                         /* destroy temporary buffer */
                         PyDataMem_UserFREE(nip1, new->elsize,
-                                           current_handler->allocator);
+                                           &current_handler->allocator);
                     }
                     goto finish;
                 }
@@ -3121,11 +3121,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         if (swap || new->alignment > 1) {
             if (nip1 != ip1 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip1, new->elsize, current_handler->allocator);
+                PyDataMem_UserFREE(nip1, new->elsize, &current_handler->allocator);
             }
             if (nip2 != ip2 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip2, new->elsize, current_handler->allocator);
+                PyDataMem_UserFREE(nip2, new->elsize, &current_handler->allocator);
             }
         }
         if (res != 0) {

--- a/numpy/core/src/multiarray/ctors.c
+++ b/numpy/core/src/multiarray/ctors.c
@@ -824,10 +824,10 @@ PyArray_NewFromDescr_int(
          */
         if (zeroed || PyDataType_FLAGCHK(descr, NPY_NEEDS_INIT)) {
             data = PyDataMem_UserNEW_ZEROED(nbytes, 1,
-                                            fa->mem_handler->allocator);
+                                            &fa->mem_handler->allocator);
         }
         else {
-            data = PyDataMem_UserNEW(nbytes, fa->mem_handler->allocator);
+            data = PyDataMem_UserNEW(nbytes, &fa->mem_handler->allocator);
         }
         if (data == NULL) {
             raise_memory_error(fa->nd, fa->dimensions, descr);
@@ -3410,7 +3410,7 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
         if (num < 0 && thisbuf == size) {
             totalbytes += bytes;
             tmp = PyDataMem_UserRENEW(PyArray_DATA(r), totalbytes,
-                                  PyArray_HANDLER(r)->allocator);
+                                  &PyArray_HANDLER(r)->allocator);
             if (tmp == NULL) {
                 err = 1;
                 break;
@@ -3433,7 +3433,7 @@ array_from_text(PyArray_Descr *dtype, npy_intp num, char const *sep, size_t *nre
 
         if (nsize != 0) {
             tmp = PyDataMem_UserRENEW(PyArray_DATA(r), nsize,
-                                  PyArray_HANDLER(r)->allocator);
+                                  &PyArray_HANDLER(r)->allocator);
             if (tmp == NULL) {
                 err = 1;
             }
@@ -3539,7 +3539,7 @@ PyArray_FromFile(FILE *fp, PyArray_Descr *dtype, npy_intp num, char *sep)
         char *tmp;
 
         if((tmp = PyDataMem_UserRENEW(PyArray_DATA(ret), nsize,
-                                     PyArray_HANDLER(ret)->allocator)) == NULL) {
+                                     &PyArray_HANDLER(ret)->allocator)) == NULL) {
             Py_DECREF(dtype);
             Py_DECREF(ret);
             return PyErr_NoMemory();
@@ -3824,7 +3824,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
             elcount = (i >> 1) + (i < 4 ? 4 : 2) + i;
             if (!npy_mul_with_overflow_intp(&nbytes, elcount, elsize)) {
                 new_data = PyDataMem_UserRENEW(PyArray_DATA(ret), nbytes,
-                                  PyArray_HANDLER(ret)->allocator);
+                                  &PyArray_HANDLER(ret)->allocator);
             }
             else {
                 new_data = NULL;
@@ -3866,7 +3866,7 @@ PyArray_FromIter(PyObject *obj, PyArray_Descr *dtype, npy_intp count)
         goto done;
     }
     new_data = PyDataMem_UserRENEW(PyArray_DATA(ret), i * elsize,
-                                   PyArray_HANDLER(ret)->allocator);
+                                   &PyArray_HANDLER(ret)->allocator);
     if (new_data == NULL) {
         PyErr_SetString(PyExc_MemoryError,
                 "cannot allocate array memory");

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -394,7 +394,7 @@ array_data_set(PyArrayObject *self, PyObject *op, void *NPY_UNUSED(ignored))
             nbytes = dtype->elsize ? dtype->elsize : 1;
         }
         PyDataMem_UserFREE(PyArray_DATA(self), nbytes,
-                           PyArray_HANDLER(self)->allocator);
+                           &PyArray_HANDLER(self)->allocator);
     }
     if (PyArray_BASE(self)) {
         if ((PyArray_FLAGS(self) & NPY_ARRAY_WRITEBACKIFCOPY) ||

--- a/numpy/core/src/multiarray/item_selection.c
+++ b/numpy/core/src/multiarray/item_selection.c
@@ -970,7 +970,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
     size = it->size;
 
     if (needcopy) {
-        buffer = PyDataMem_UserNEW(N * elsize, current_handler->allocator);
+        buffer = PyDataMem_UserNEW(N * elsize, &current_handler->allocator);
         if (buffer == NULL) {
             ret = -1;
             goto fail;
@@ -1055,7 +1055,7 @@ _new_sortlike(PyArrayObject *op, int axis, PyArray_SortFunc *sort,
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
     /* cleanup internal buffer */
-    PyDataMem_UserFREE(buffer, N * elsize, current_handler->allocator);
+    PyDataMem_UserFREE(buffer, N * elsize, &current_handler->allocator);
     if (ret < 0 && !PyErr_Occurred()) {
         /* Out of memory during sorting or buffer creation */
         PyErr_NoMemory();
@@ -1117,7 +1117,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
     size = it->size;
 
     if (needcopy) {
-        valbuffer = PyDataMem_UserNEW(N * elsize, current_handler->allocator);
+        valbuffer = PyDataMem_UserNEW(N * elsize, &current_handler->allocator);
         if (valbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1126,7 +1126,7 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 
     if (needidxbuffer) {
         idxbuffer = (npy_intp *)PyDataMem_UserNEW(N * sizeof(npy_intp),
-                                                  current_handler->allocator);
+                                                  &current_handler->allocator);
         if (idxbuffer == NULL) {
             ret = -1;
             goto fail;
@@ -1216,8 +1216,8 @@ _new_argsortlike(PyArrayObject *op, int axis, PyArray_ArgSortFunc *argsort,
 fail:
     NPY_END_THREADS_DESCR(PyArray_DESCR(op));
     /* cleanup internal buffers */
-    PyDataMem_UserFREE(valbuffer, N * elsize, current_handler->allocator);
-    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), current_handler->allocator);
+    PyDataMem_UserFREE(valbuffer, N * elsize, &current_handler->allocator);
+    PyDataMem_UserFREE(idxbuffer, N * sizeof(npy_intp), &current_handler->allocator);
     if (ret < 0) {
         if (!PyErr_Occurred()) {
             /* Out of memory during sorting or buffer creation */

--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2054,7 +2054,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
          * line 820
          */
         PyDataMem_UserFREE(PyArray_DATA(self), n_tofree,
-                           PyArray_HANDLER(self)->allocator);
+                           &PyArray_HANDLER(self)->allocator);
         PyArray_CLEARFLAGS(self, NPY_ARRAY_OWNDATA);
     }
     Py_XDECREF(PyArray_BASE(self));
@@ -2100,7 +2100,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
             }
             /* Store the functions in case the global handler is modified */
             fa->mem_handler = current_handler;
-            fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
+            fa->data = PyDataMem_UserNEW(num, &PyArray_HANDLER(fa)->allocator);
             if (PyArray_DATA(self) == NULL) {
                 Py_DECREF(rawdata);
                 return PyErr_NoMemory();
@@ -2154,7 +2154,7 @@ array_setstate(PyArrayObject *self, PyObject *args)
         }
         /* Store the functions in case the global handler is modified */
         fa->mem_handler = current_handler;
-        fa->data = PyDataMem_UserNEW(num, PyArray_HANDLER(fa)->allocator);
+        fa->data = PyDataMem_UserNEW(num, &PyArray_HANDLER(fa)->allocator);
         if (PyArray_DATA(self) == NULL) {
             return PyErr_NoMemory();
         }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -122,7 +122,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         /* Reallocate space if needed - allocating 0 is forbidden */
         new_data = PyDataMem_UserRENEW(PyArray_DATA(self),
                                        newnbytes == 0 ? elsize : newnbytes,
-                                       PyArray_HANDLER(self)->allocator);
+                                       &PyArray_HANDLER(self)->allocator);
         if (new_data == NULL) {
             PyErr_SetString(PyExc_MemoryError,
                     "cannot allocate memory for array");


### PR DESCRIPTION
In the previous implementation `PyDataMem_UserNEW/NEW_ZEROED/RENEW/FREE` functions included special handling for the default allocator, because:

* `npy_*_cache/PyDataMem_RENEW` API is not compatible with the new `PyDataMem_Allocator` routines
* `npy_*_cache/PyDataMem_RENEW` API already integrates tracemalloc/eventhook logic

In the proposed implementation the `default_handler` is transformed to common handler (like the user-defined ones). The main change is that now `PyDataMem_NEW/NEW_ZEROED/RENEW/FREE` functions are not involved in the default allocator routines since they overlap with `PyDataMem_UserNEW/NEW_ZEROED/RENEW/FREE`s' code.

The benefits include:

* No (default_handler-specific) confusing conditions inside `PyDataMem_User*` functions.
* **Consistency**
* `PyDataMem_SetHandler` consumers can now have access to the `default_handler`'s allocator routines, which makes https://github.com/numpy/numpy/pull/19404#issuecomment-879343283 fallback allocation scenario possible.

Generally, I am very confident of this change.