### PR TITLE
Implement thread-locality for PyPy

### DIFF
--- a/numpy/core/src/multiarray/alloc.c
+++ b/numpy/core/src/multiarray/alloc.c
@@ -386,7 +386,9 @@ PyDataMem_Handler default_handler = {
     }
 };
 
+#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
 PyObject *current_handler;
+#endif
 
 int uo_index=0;   /* user_override index */
 
@@ -482,6 +484,7 @@ PyDataMem_SetHandler(PyDataMem_Handler *handler)
     PyObject *capsule;
     PyObject *old_capsule;
     PyDataMem_Handler *old_handler;
+#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     PyObject *token;
     if (PyContextVar_Get(current_handler, NULL, &old_capsule)) {
         return NULL;
@@ -510,6 +513,42 @@ PyDataMem_SetHandler(PyDataMem_Handler *handler)
     }
     Py_DECREF(token);
     return old_handler;
+#else
+    PyObject *p;
+    p = PyThreadState_GetDict();
+    if (p == NULL) {
+        return NULL;
+    }
+    old_capsule = PyDict_GetItemString(p, "current_allocator");
+    if (old_capsule == NULL) {
+        old_handler = &default_handler;
+    }
+    else {
+        old_handler = (PyDataMem_Handler *) PyCapsule_GetPointer(old_capsule, NULL);
+        Py_DECREF(old_capsule);
+        if (old_handler == NULL) {
+            return NULL;
+        }
+    }
+    if (handler != NULL) {
+        capsule = PyCapsule_New(handler, NULL, NULL);
+        if (capsule == NULL) {
+            return NULL;
+        }
+    }
+    else {
+        capsule = PyCapsule_New(&default_handler, NULL, NULL);
+        if (capsule == NULL) {
+            return NULL;
+        }
+    }
+    const int error = PyDict_SetItemString(p, "current_allocator", capsule);
+    Py_DECREF(capsule);
+    if (error) {
+        return NULL;
+    }
+    return old_handler;
+#endif
 }
 
 /*NUMPY_API
@@ -523,6 +562,7 @@ PyDataMem_GetHandler(PyArrayObject *obj)
     PyObject *base;
     PyObject *capsule;
     PyDataMem_Handler *handler;
+#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     if (obj == NULL) {
         if (PyContextVar_Get(current_handler, NULL, &capsule)) {
             return NULL;
@@ -531,6 +571,24 @@ PyDataMem_GetHandler(PyArrayObject *obj)
         Py_DECREF(capsule);
         return handler;
     }
+#else
+    PyObject *p;
+    if (obj == NULL) {
+        p = PyThreadState_GetDict();
+        if (p == NULL) {
+            return NULL;
+        }
+        capsule = PyDict_GetItemString(p, "current_allocator");
+        if (capsule == NULL) {
+            handler = &default_handler;
+        }
+        else {
+            handler = (PyDataMem_Handler *) PyCapsule_GetPointer(capsule, NULL);
+            Py_DECREF(capsule);
+        }
+        return handler;
+    }
+#endif
     /* If there's a handler, the array owns its own datay */
     handler = PyArray_HANDLER(obj);
     if (handler == NULL) {

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -39,8 +39,10 @@ npy_free_cache_dim_array(PyArrayObject * arr)
     npy_free_cache_dim(PyArray_DIMS(arr), PyArray_NDIM(arr));
 }
 
+#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
 extern PyObject *current_handler; /* PyContextVar/PyCapsule */
 extern PyDataMem_Handler default_handler;
+#endif
 
 NPY_NO_EXPORT PyObject *
 get_handler_name(PyObject *NPY_UNUSED(self), PyObject *obj);

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4908,6 +4908,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     if (initumath(m) != 0) {
         goto err;
     }
+#if (!defined(PYPY_VERSION_NUM) || PYPY_VERSION_NUM >= 0x07030600)
     /*
      * Initialize the context-local PyDataMem_Handler capsule.
      */
@@ -4920,6 +4921,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     if (current_handler == NULL) {
         goto err;
     }
+#endif
     return m;
 
  err:

--- a/numpy/core/tests/test_mem_policy.py
+++ b/numpy/core/tests/test_mem_policy.py
@@ -205,6 +205,9 @@ async def async_test_context_locality(get_module):
 
 
 def test_context_locality(get_module):
+    if sys.implementation.name == 'pypy' and sys.pypy_version_info[:3] < (7, 3,
+                                                                          6):
+        pytest.skip('no context-locality support in PyPy < 7.3.6')
     asyncio.run(async_test_context_locality(get_module))
 
 


### PR DESCRIPTION
* Is it safe to assume that `PyContextVar` will be supported in the next PyPy release?
* No "uh-oh, unmatched" warnings appear in PyPy.