### PR TITLE
Implement allocator lifetime management

### DIFF
--- a/doc/source/reference/c-api/data_memory.rst
+++ b/doc/source/reference/c-api/data_memory.rst
@@ -77,7 +77,7 @@ reallocate or free the data memory of the instance.
             void (*free) (void *ctx, void *ptr, size_t size);
         } PyDataMemAllocator;
 
-.. c:function:: const PyDataMem_Handler * PyDataMem_SetHandler(PyDataMem_Handler *handler)
+.. c:function:: PyObject * PyDataMem_SetHandler(PyObject *handler)
 
    Set a new allocation policy. If the input value is ``NULL``, will reset the
    policy to the default. Return the previous policy, or
@@ -85,7 +85,7 @@ reallocate or free the data memory of the instance.
    so they will still call the python and numpy memory management callback
    hooks.
     
-.. c:function:: const PyDataMem_Handler * PyDataMem_GetHandler()
+.. c:function:: PyObject * PyDataMem_GetHandler()
 
    Return the current policy that will be used to allocate data for the
    next ``PyArrayObject``. On failure, return ``NULL``.

--- a/numpy/core/include/numpy/ndarraytypes.h
+++ b/numpy/core/include/numpy/ndarraytypes.h
@@ -735,7 +735,7 @@ typedef struct tagPyArrayObject_fields {
     /*
      * For malloc/calloc/realloc/free per object
      */
-    PyDataMem_Handler *mem_handler;
+    PyObject *mem_handler;
 } PyArrayObject_fields;
 
 /*
@@ -1675,6 +1675,12 @@ static NPY_INLINE void
 PyArray_CLEARFLAGS(PyArrayObject *arr, int flags)
 {
     ((PyArrayObject_fields *)arr)->flags &= ~flags;
+}
+
+static NPY_INLINE NPY_RETURNS_BORROWED_REF PyObject *
+PyArray_HANDLER(PyArrayObject *arr)
+{
+    return ((PyArrayObject_fields *)arr)->mem_handler;
 }
 
 #define PyTypeNum_ISBOOL(type) ((type) == NPY_BOOL)

--- a/numpy/core/src/multiarray/alloc.h
+++ b/numpy/core/src/multiarray/alloc.h
@@ -10,16 +10,16 @@ NPY_NO_EXPORT PyObject *
 _set_madvise_hugepage(PyObject *NPY_UNUSED(self), PyObject *enabled_obj);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW(npy_uintp sz, const PyDataMemAllocator *allocator);
+PyDataMem_UserNEW(npy_uintp sz, PyObject *mem_handler);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, const PyDataMemAllocator *allocator);
+PyDataMem_UserNEW_ZEROED(size_t nmemb, size_t size, PyObject *mem_handler);
 
 NPY_NO_EXPORT void
-PyDataMem_UserFREE(void * p, npy_uintp sd, const PyDataMemAllocator *allocator);
+PyDataMem_UserFREE(void * p, npy_uintp sd, PyObject *mem_handler);
 
 NPY_NO_EXPORT void *
-PyDataMem_UserRENEW(void *ptr, size_t size, const PyDataMemAllocator *allocator);
+PyDataMem_UserRENEW(void *ptr, size_t size, PyObject *mem_handler);
 
 NPY_NO_EXPORT void *
 npy_alloc_cache_dim(npy_uintp sz);
@@ -46,8 +46,5 @@ extern PyDataMem_Handler default_handler;
 
 NPY_NO_EXPORT PyObject *
 get_handler_name(PyObject *NPY_UNUSED(self), PyObject *obj);
-
-
-#define PyArray_HANDLER(arr) ((PyArrayObject_fields*)(arr))->mem_handler
 
 #endif

--- a/numpy/core/src/multiarray/arrayobject.c
+++ b/numpy/core/src/multiarray/arrayobject.c
@@ -501,7 +501,8 @@ array_dealloc(PyArrayObject *self)
         if (nbytes == 0) {
             nbytes = fa->descr->elsize ? fa->descr->elsize : 1;
         }
-        PyDataMem_UserFREE(fa->data, nbytes, &fa->mem_handler->allocator);
+        PyDataMem_UserFREE(fa->data, nbytes, fa->mem_handler);
+        Py_DECREF(fa->mem_handler);
     }
 
     /* must match allocation in PyArray_NewFromDescr */

--- a/numpy/core/src/multiarray/arraytypes.c.src
+++ b/numpy/core/src/multiarray/arraytypes.c.src
@@ -3093,7 +3093,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
     if (!PyArray_HASFIELDS(ap)) {
         return STRING_compare(ip1, ip2, ap);
     }
-    const PyDataMem_Handler *mem_handler = PyDataMem_GetHandler();
+    PyObject *mem_handler = PyDataMem_GetHandler();
     if (mem_handler == NULL) {
         goto finish;
     }
@@ -3123,7 +3123,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip1 = PyDataMem_UserNEW(new->elsize, &mem_handler->allocator);
+                nip1 = PyDataMem_UserNEW(new->elsize, mem_handler);
                 if (nip1 == NULL) {
                     goto finish;
                 }
@@ -3136,12 +3136,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
                  * create temporary buffer and copy,
                  * always use the current handler for internal allocations
                  */
-                nip2 = PyDataMem_UserNEW(new->elsize, &mem_handler->allocator);
+                nip2 = PyDataMem_UserNEW(new->elsize, mem_handler);
                 if (nip2 == NULL) {
                     if (nip1 != ip1 + offset) {
                         /* destroy temporary buffer */
-                        PyDataMem_UserFREE(nip1, new->elsize,
-                                           &mem_handler->allocator);
+                        PyDataMem_UserFREE(nip1, new->elsize, mem_handler);
                     }
                     goto finish;
                 }
@@ -3154,11 +3153,11 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
         if (swap || new->alignment > 1) {
             if (nip1 != ip1 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip1, new->elsize, &mem_handler->allocator);
+                PyDataMem_UserFREE(nip1, new->elsize, mem_handler);
             }
             if (nip2 != ip2 + offset) {
                 /* destroy temporary buffer */
-                PyDataMem_UserFREE(nip2, new->elsize, &mem_handler->allocator);
+                PyDataMem_UserFREE(nip2, new->elsize, mem_handler);
             }
         }
         if (res != 0) {
@@ -3167,6 +3166,7 @@ VOID_compare(char *ip1, char *ip2, PyArrayObject *ap)
     }
 
 finish:
+    Py_XDECREF(mem_handler);
     return res;
 }
 

--- a/numpy/core/src/multiarray/getset.c
+++ b/numpy/core/src/multiarray/getset.c
@@ -393,14 +393,14 @@ array_data_set(PyArrayObject *self, PyObject *op, void *NPY_UNUSED(ignored))
             PyArray_Descr *dtype = PyArray_DESCR(self);
             nbytes = dtype->elsize ? dtype->elsize : 1;
         }
-        PyDataMem_Handler *handler = PyArray_HANDLER(self);
+        PyObject *handler = PyArray_HANDLER(self);
         if (handler == NULL) {
             /* This can happen if someone arbitrarily sets NPY_ARRAY_OWNDATA */
             PyErr_SetString(PyExc_RuntimeError,
                             "no memory handler found but OWNDATA flag set");
             return -1;
         }
-        PyDataMem_UserFREE(PyArray_DATA(self), nbytes, &handler->allocator);
+        PyDataMem_UserFREE(PyArray_DATA(self), nbytes, handler);
     }
     if (PyArray_BASE(self)) {
         if ((PyArray_FLAGS(self) & NPY_ARRAY_WRITEBACKIFCOPY) ||

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -4912,7 +4912,7 @@ PyMODINIT_FUNC PyInit__multiarray_umath(void) {
     /*
      * Initialize the context-local PyDataMem_Handler capsule.
      */
-    c_api = PyCapsule_New(&default_handler, NULL, NULL);
+    c_api = PyCapsule_New(&default_handler, "mem_handler", NULL);
     if (c_api == NULL) {
         goto err;
     }

--- a/numpy/core/src/multiarray/shape.c
+++ b/numpy/core/src/multiarray/shape.c
@@ -120,7 +120,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         }
 
         /* Reallocate space if needed - allocating 0 is forbidden */
-        PyDataMem_Handler *handler = PyArray_HANDLER(self);
+        PyObject *handler = PyArray_HANDLER(self);
         if (handler == NULL) {
             /* This can happen if someone arbitrarily sets NPY_ARRAY_OWNDATA */
             PyErr_SetString(PyExc_RuntimeError,
@@ -129,7 +129,7 @@ PyArray_Resize(PyArrayObject *self, PyArray_Dims *newshape, int refcheck,
         }
         new_data = PyDataMem_UserRENEW(PyArray_DATA(self),
                                        newnbytes == 0 ? elsize : newnbytes,
-                                       &handler->allocator);
+                                       handler);
         if (new_data == NULL) {
             PyErr_SetString(PyExc_MemoryError,
                     "cannot allocate memory for array");


### PR DESCRIPTION
* `PyDataMem_GetHandler/SetHandler` accept/return `PyCapsule`s of `PyDataMem_Handler`s.
* New referneces to these handler capsules are directly stored in the (context/thread-local) current allocator.
* Each array now stores a new reference to a handler capsule.
* `PyArray_HANDLER` returns a borrowed reference to the array's handler capsule (if any).

**Benefit**
Now `PyDataMem_Handler` structs can be mortal. A user may create a new handler (encapsulate it with a destructor), use it for the allocation of several arrays, delete any references to that capsule. The handler capsule will be garbage collected after every array that uses it is deallocated.

---

~I am still hunting a weird segfault.~