### PR TITLE
ENH: add inner loop functions for indexed loops and use them in ufunc_at

### DIFF
--- a/benchmarks/benchmarks/bench_ufunc_strides.py
+++ b/benchmarks/benchmarks/bench_ufunc_strides.py
@@ -150,7 +150,7 @@ class Mandelbrot(Benchmark):
         return np.sum(np.multiply(z,z) + c)
 
     def mandelbrot_numpy(self, c, maxiter):
-        output = np.zeros(c.shape, np.int)
+        output = np.zeros(c.shape, np.int32)
         z = np.empty(c.shape, np.complex64)
         for it in range(maxiter):
             notdone = self.f(z)

--- a/doc/release/upcoming_changes/23136.performance.rst
+++ b/doc/release/upcoming_changes/23136.performance.rst
@@ -1,0 +1,17 @@
+``ufunc.at`` can be much faster
+-------------------------------
+If called on ufuncs with appropriate indexed loops, ``ufunc.at`` can be up to
+60x faster. Generic ``ufunc.at`` can be up to 9x faster. The conditions for
+any speedup::
+
+- contiguous arguments
+- no casting
+
+The conditions for the extra speedup::
+
+- calling the ufuncs ``add``, ``subtract``, ``multiply``, ``divide`` (and
+  ``floor_divide``)
+- 1d arguments
+
+The internal logic is similar to the logic used for regular ufuncs, which also
+have a fast path for contiguous, non-casting, 1d arrays.

--- a/doc/release/upcoming_changes/23136.performance.rst
+++ b/doc/release/upcoming_changes/23136.performance.rst
@@ -1,17 +1,17 @@
 ``ufunc.at`` can be much faster
 -------------------------------
-If called on ufuncs with appropriate indexed loops, ``ufunc.at`` can be up to
-60x faster. Generic ``ufunc.at`` can be up to 9x faster. The conditions for
-any speedup::
+Generic ``ufunc.at`` can be up to 9x faster. The conditions for this speedup:
 
 - contiguous arguments
 - no casting
 
-The conditions for the extra speedup::
-
-- calling the ufuncs ``add``, ``subtract``, ``multiply``, ``divide`` (and
-  ``floor_divide``)
-- 1d arguments
+If ufuncs with appropriate indexed loops on 1d arguments with the above
+conditions, ``ufunc.at`` can be up to 60x faster (an additional 7x speedup).
+Appropriate indexed loops have been added to ``add``, ``subtract``,
+``multiply``, ``divide`` (and ``floor_divide``)
 
 The internal logic is similar to the logic used for regular ufuncs, which also
 have a fast path for contiguous, non-casting, 1d arrays.
+
+Thanks to the `D. E. Shaw group <https://deshaw.com/>`_ for sponsoring this
+work.

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -1,3 +1,8 @@
+"""
+Generate the code to build all the internal ufuncs. At the base is the defdict:
+a dictionary ofUfunc classes. This is fed to make_code to generate
+__umath_generated.c
+"""
 import os
 import re
 import struct
@@ -5,6 +10,7 @@ import sys
 import textwrap
 import argparse
 
+# identity objects
 Zero = "PyLong_FromLong(0)"
 One = "PyLong_FromLong(1)"
 True_ = "(Py_INCREF(Py_True), Py_True)"
@@ -125,7 +131,7 @@ def check_td_order(tds):
         _check_order(signatures[prev_i], sign)
 
 
-_fdata_map = dict(
+_floatformat_map = dict(
     e='npy_%sf',
     f='npy_%sf',
     d='npy_%s',
@@ -136,11 +142,13 @@ _fdata_map = dict(
 )
 
 def build_func_data(types, f):
-    func_data = [_fdata_map.get(t, '%s') % (f,) for t in types]
+    func_data = [_floatformat_map.get(t, '%s') % (f,) for t in types]
     return func_data
 
 def TD(types, f=None, astype=None, in_=None, out=None, cfunc_alias=None,
        simd=None, dispatch=None):
+    """Generate a TypeDescription instance for each item in types
+    """
     if f is not None:
         if isinstance(f, str):
             func_data = build_func_data(types, f)
@@ -188,12 +196,15 @@ class Ufunc:
     ----------
     nin : number of input arguments
     nout : number of output arguments
-    identity : identity element for a two-argument function
+    identity : identity element for a two-argument function (like Zero)
     docstring : docstring for the ufunc
-    type_descriptions : list of TypeDescription objects
+    typereso: type resolver function of type PyUFunc_TypeResolutionFunc
+    type_descriptions : TypeDescription objects
+    signature: a generalized ufunc signature (like for matmul)
+    indexed: add indexed loops (ufunc.at) for these type characters
     """
     def __init__(self, nin, nout, identity, docstring, typereso,
-                 *type_descriptions, signature=None):
+                 *type_descriptions, signature=None, indexed=''):
         self.nin = nin
         self.nout = nout
         if identity is None:
@@ -203,6 +214,7 @@ class Ufunc:
         self.typereso = typereso
         self.type_descriptions = []
         self.signature = signature
+        self.indexed = indexed
         for td in type_descriptions:
             self.type_descriptions.extend(td)
         for td in self.type_descriptions:
@@ -347,6 +359,7 @@ defdict = {
            TypeDescription('M', FullTypeDescr, 'mM', 'M'),
           ],
           TD(O, f='PyNumber_Add'),
+          indexed=flts + ints
           ),
 'subtract':
     Ufunc(2, 1, None, # Zero is only a unit to the right, not the left
@@ -359,6 +372,7 @@ defdict = {
            TypeDescription('M', FullTypeDescr, 'MM', 'm'),
           ],
           TD(O, f='PyNumber_Subtract'),
+          indexed=flts + ints
           ),
 'multiply':
     Ufunc(2, 1, One,
@@ -374,6 +388,7 @@ defdict = {
            TypeDescription('m', FullTypeDescr, 'dm', 'm'),
           ],
           TD(O, f='PyNumber_Multiply'),
+          indexed=flts + ints
           ),
 #'true_divide' : aliased to divide in umathmodule.c:initumath
 'floor_divide':
@@ -388,6 +403,7 @@ defdict = {
            TypeDescription('m', FullTypeDescr, 'mm', 'q'),
           ],
           TD(O, f='PyNumber_FloorDivide'),
+          indexed=flts + ints
           ),
 'divide':
     Ufunc(2, 1, None, # One is only a unit to the right, not the left
@@ -1255,6 +1271,40 @@ def make_ufuncs(funcdict):
         if uf.typereso is not None:
             mlist.append(
                 r"((PyUFuncObject *)f)->type_resolver = &%s;" % uf.typereso)
+        for c in uf.indexed:
+            # Handle indexed loops by getting the underlying ArrayMethodObject
+            # from the list in f._loops and setting its field appropriately
+            fmt = textwrap.dedent("""
+            {{
+                PyArray_DTypeMeta *dtype = PyArray_DTypeFromTypeNum({typenum});
+                PyObject *info = get_info_no_cast((PyUFuncObject *)f, dtype, {count});
+                if (info == NULL) {{
+                    return -1;
+                }}
+                if (info == Py_None) {{
+                    PyErr_SetString(PyExc_RuntimeError,
+                        "cannot add indexed loop to ufunc {name} with {typenum}");
+                    return -1;
+                }}
+                if (!PyObject_TypeCheck(info, &PyArrayMethod_Type)) {{
+                    PyErr_SetString(PyExc_RuntimeError,
+                        "Not a PyArrayMethodObject in ufunc {name} with {typenum}");
+                }}
+                ((PyArrayMethodObject*)info)->contiguous_indexed_loop = {funcname};
+                /* info is borrowed, no need to decref*/
+            }}    
+            """)
+            cname = name
+            if cname == "floor_divide":
+                # XXX there must be a better way...
+                cname = "divide"
+            mlist.append(fmt.format(
+                typenum=f"NPY_{english_upper(chartoname[c])}",
+                count=uf.nin+uf.nout,
+                name=name,
+                funcname = f"{english_upper(chartoname[c])}_{cname}_indexed",
+            ))
+            
         mlist.append(r"""PyDict_SetItemString(dictionary, "%s", f);""" % name)
         mlist.append(r"""Py_DECREF(f);""")
         code3list.append('\n'.join(mlist))
@@ -1277,8 +1327,46 @@ def make_code(funcdict, filename):
     #include "loops.h"
     #include "matmul.h"
     #include "clip.h"
+    #include "dtypemeta.h"
     #include "_umath_doc_generated.h"
+
     %s
+    /*
+     * Return the PyArrayMethodObject or PyCapsule that matches a registered
+     * tuple of identical dtypes. Return a borrowed ref of the first match.
+     */
+    static PyObject *
+    get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype, int ndtypes)
+    {
+        
+        PyObject *t_dtypes = PyTuple_New(ndtypes);
+        if (t_dtypes == NULL) {
+            return NULL;
+        }
+        for (int i=0; i < ndtypes; i++) {
+            PyTuple_SetItem(t_dtypes, i, (PyObject *)op_dtype);
+        }
+        PyObject *loops = ufunc->_loops;
+        Py_ssize_t length = PyList_Size(loops);
+        for (Py_ssize_t i = 0; i < length; i++) {
+            PyObject *item = PyList_GetItem(loops, i);
+            PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
+            int cmp = PyObject_RichCompareBool(cur_DType_tuple, t_dtypes, Py_EQ);
+            if (cmp < 0) {
+                Py_DECREF(t_dtypes);
+                return NULL;
+            }
+            if (cmp == 0) {
+                continue;
+            }
+            /* Got the match */
+            Py_DECREF(t_dtypes);
+            return PyTuple_GetItem(item, 1); 
+        }
+        Py_DECREF(t_dtypes);
+        Py_RETURN_NONE;
+    }
+
 
     static int
     InitOperators(PyObject *dictionary) {

--- a/numpy/core/code_generators/generate_umath.py
+++ b/numpy/core/code_generators/generate_umath.py
@@ -127,7 +127,7 @@ def check_td_order(tds):
     for prev_i, sign in enumerate(signatures[1:]):
         if sign in signatures[:prev_i+1]:
             continue  # allow duplicates...
-        
+
         _check_order(signatures[prev_i], sign)
 
 
@@ -1277,22 +1277,26 @@ def make_ufuncs(funcdict):
             fmt = textwrap.dedent("""
             {{
                 PyArray_DTypeMeta *dtype = PyArray_DTypeFromTypeNum({typenum});
-                PyObject *info = get_info_no_cast((PyUFuncObject *)f, dtype, {count});
+                PyObject *info = get_info_no_cast((PyUFuncObject *)f,
+                                                   dtype, {count});
                 if (info == NULL) {{
                     return -1;
                 }}
                 if (info == Py_None) {{
                     PyErr_SetString(PyExc_RuntimeError,
-                        "cannot add indexed loop to ufunc {name} with {typenum}");
+                        "cannot add indexed loop to ufunc "
+                        "{name} with {typenum}");
                     return -1;
                 }}
                 if (!PyObject_TypeCheck(info, &PyArrayMethod_Type)) {{
                     PyErr_SetString(PyExc_RuntimeError,
-                        "Not a PyArrayMethodObject in ufunc {name} with {typenum}");
+                        "Not a PyArrayMethodObject in ufunc "
+                        "{name} with {typenum}");
                 }}
-                ((PyArrayMethodObject*)info)->contiguous_indexed_loop = {funcname};
+                ((PyArrayMethodObject*)info)->contiguous_indexed_loop =
+                                                                 {funcname};
                 /* info is borrowed, no need to decref*/
-            }}    
+            }}
             """)
             cname = name
             if cname == "floor_divide":
@@ -1304,7 +1308,7 @@ def make_ufuncs(funcdict):
                 name=name,
                 funcname = f"{english_upper(chartoname[c])}_{cname}_indexed",
             ))
-            
+
         mlist.append(r"""PyDict_SetItemString(dictionary, "%s", f);""" % name)
         mlist.append(r"""Py_DECREF(f);""")
         code3list.append('\n'.join(mlist))
@@ -1336,9 +1340,10 @@ def make_code(funcdict, filename):
      * tuple of identical dtypes. Return a borrowed ref of the first match.
      */
     static PyObject *
-    get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype, int ndtypes)
+    get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype,
+                     int ndtypes)
     {
-        
+
         PyObject *t_dtypes = PyTuple_New(ndtypes);
         if (t_dtypes == NULL) {
             return NULL;
@@ -1351,7 +1356,8 @@ def make_code(funcdict, filename):
         for (Py_ssize_t i = 0; i < length; i++) {
             PyObject *item = PyList_GetItem(loops, i);
             PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
-            int cmp = PyObject_RichCompareBool(cur_DType_tuple, t_dtypes, Py_EQ);
+            int cmp = PyObject_RichCompareBool(cur_DType_tuple,
+                                               t_dtypes, Py_EQ);
             if (cmp < 0) {
                 Py_DECREF(t_dtypes);
                 return NULL;
@@ -1361,7 +1367,7 @@ def make_code(funcdict, filename):
             }
             /* Got the match */
             Py_DECREF(t_dtypes);
-            return PyTuple_GetItem(item, 1); 
+            return PyTuple_GetItem(item, 1);
         }
         Py_DECREF(t_dtypes);
         Py_RETURN_NONE;

--- a/numpy/core/include/numpy/experimental_dtype_api.h
+++ b/numpy/core/include/numpy/experimental_dtype_api.h
@@ -311,6 +311,7 @@ typedef NPY_CASTING (resolve_descriptors_function)(
 #define NPY_METH_contiguous_loop 5
 #define NPY_METH_unaligned_strided_loop 6
 #define NPY_METH_unaligned_contiguous_loop 7
+#define NPY_METH_contiguous_indexed_loop 8
 
 
 typedef struct {
@@ -488,7 +489,7 @@ PyArray_GetDefaultDescr(PyArray_DTypeMeta *DType)
  */
 #if !defined(NO_IMPORT) && !defined(NO_IMPORT_ARRAY)
 
-#define __EXPERIMENTAL_DTYPE_VERSION 6
+#define __EXPERIMENTAL_DTYPE_VERSION 7
 
 static int
 import_experimental_dtype_api(int version)

--- a/numpy/core/src/multiarray/argfunc.dispatch.c.src
+++ b/numpy/core/src/multiarray/argfunc.dispatch.c.src
@@ -194,7 +194,7 @@ simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
         npyv_@bsfx@ nnan_ab = npyv_and_@bsfx@(nnan_a, nnan_b);
         npyv_@bsfx@ nnan_cd = npyv_and_@bsfx@(nnan_c, nnan_d);
         npy_uint64 nnan = npyv_tobits_@bsfx@(npyv_and_@bsfx@(nnan_ab, nnan_cd));
-        if ((long long int)nnan != ((1LL << vstep) - 1)) {
+        if ((unsigned long long int)nnan != ((1ULL << vstep) - 1)) {
             npy_uint64 nnan_4[4];
             nnan_4[0] = npyv_tobits_@bsfx@(nnan_a);
             nnan_4[1] = npyv_tobits_@bsfx@(nnan_b);
@@ -219,7 +219,7 @@ simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
     #if @is_fp@
         npyv_@bsfx@ nnan_a = npyv_notnan_@sfx@(a);
         npy_uint64 nnan = npyv_tobits_@bsfx@(nnan_a);
-        if ((long long int)nnan != ((1LL << vstep) - 1)) {
+        if ((unsigned long long int)nnan != ((1ULL << vstep) - 1)) {
             for (int vi = 0; vi < vstep; ++vi) {
                 if (!((nnan >> vi) & 1)) {
                     return i + vi;

--- a/numpy/core/src/multiarray/argfunc.dispatch.c.src
+++ b/numpy/core/src/multiarray/argfunc.dispatch.c.src
@@ -194,7 +194,7 @@ simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
         npyv_@bsfx@ nnan_ab = npyv_and_@bsfx@(nnan_a, nnan_b);
         npyv_@bsfx@ nnan_cd = npyv_and_@bsfx@(nnan_c, nnan_d);
         npy_uint64 nnan = npyv_tobits_@bsfx@(npyv_and_@bsfx@(nnan_ab, nnan_cd));
-        if (nnan != ((1LL << vstep) - 1)) {
+        if ((long long int)nnan != ((1LL << vstep) - 1)) {
             npy_uint64 nnan_4[4];
             nnan_4[0] = npyv_tobits_@bsfx@(nnan_a);
             nnan_4[1] = npyv_tobits_@bsfx@(nnan_b);
@@ -219,7 +219,7 @@ simd_@func@_@sfx@(npyv_lanetype_@sfx@ *ip, npy_intp len)
     #if @is_fp@
         npyv_@bsfx@ nnan_a = npyv_notnan_@sfx@(a);
         npy_uint64 nnan = npyv_tobits_@bsfx@(nnan_a);
-        if (nnan != ((1LL << vstep) - 1)) {
+        if ((long long int)nnan != ((1LL << vstep) - 1)) {
             for (int vi = 0; vi < vstep; ++vi) {
                 if (!((nnan >> vi) & 1)) {
                     return i + vi;

--- a/numpy/core/src/multiarray/array_method.c
+++ b/numpy/core/src/multiarray/array_method.c
@@ -291,6 +291,9 @@ fill_arraymethod_from_slots(
             case NPY_METH_get_reduction_initial:
                 meth->get_reduction_initial = slot->pfunc;
                 continue;
+            case NPY_METH_contiguous_indexed_loop:
+                meth->contiguous_indexed_loop = slot->pfunc;
+                continue;
             default:
                 break;
         }
@@ -891,7 +894,7 @@ generic_masked_strided_loop(PyArrayMethod_Context *context,
 /*
  * Fetches a strided-loop function that supports a boolean mask as additional
  * (last) operand to the strided-loop.  It is otherwise largely identical to
- * the `get_loop` method which it wraps.
+ * the `get_strided_loop` method which it wraps.
  * This is the core implementation for the ufunc `where=...` keyword argument.
  *
  * NOTE: This function does not support `move_references` or inner dimensions.

--- a/numpy/core/src/multiarray/array_method.h
+++ b/numpy/core/src/multiarray/array_method.h
@@ -73,7 +73,7 @@ struct PyArrayMethodObject_tag;
  * TODO: Before making this public, we should review which information should
  *       be stored on the Context/BoundArrayMethod vs. the ArrayMethod.
  */
-typedef struct {
+typedef struct PyArrayMethod_Context_tag {
     PyObject *caller;  /* E.g. the original ufunc, may be NULL */
     struct PyArrayMethodObject_tag *method;
 
@@ -223,6 +223,7 @@ typedef struct PyArrayMethodObject_tag {
     PyArrayMethod_StridedLoop *contiguous_loop;
     PyArrayMethod_StridedLoop *unaligned_strided_loop;
     PyArrayMethod_StridedLoop *unaligned_contiguous_loop;
+    PyArrayMethod_StridedLoop *contiguous_indexed_loop;
     /* Chunk only used for wrapping array method defined in umath */
     struct PyArrayMethodObject_tag *wrapped_meth;
     PyArray_DTypeMeta **wrapped_dtypes;
@@ -266,6 +267,7 @@ extern NPY_NO_EXPORT PyTypeObject PyBoundArrayMethod_Type;
 #define NPY_METH_contiguous_loop 5
 #define NPY_METH_unaligned_strided_loop 6
 #define NPY_METH_unaligned_contiguous_loop 7
+#define NPY_METH_contiguous_indexed_loop 8
 
 
 /*

--- a/numpy/core/src/multiarray/experimental_public_dtype_api.c
+++ b/numpy/core/src/multiarray/experimental_public_dtype_api.c
@@ -16,7 +16,7 @@
 #include "common_dtype.h"
 
 
-#define EXPERIMENTAL_DTYPE_API_VERSION 6
+#define EXPERIMENTAL_DTYPE_API_VERSION 7
 
 
 typedef struct{

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -1240,3 +1240,40 @@ install_logical_ufunc_promoter(PyObject *ufunc)
 
     return PyUFunc_AddLoop((PyUFuncObject *)ufunc, info, 0);
 }
+
+/*
+ * Return the PyArrayMethodObject or PyCapsule that matches a registered
+ * tuple of identical dtypes. Return a borrowed ref of the first match.
+ */
+NPY_NO_EXPORT PyObject *
+get_info_no_cast(PyUFuncObject *ufunc, PyArray_DTypeMeta *op_dtype,
+                 int ndtypes)
+{
+    PyObject *t_dtypes = PyTuple_New(ndtypes);
+    if (t_dtypes == NULL) {
+        return NULL;
+    }
+    for (int i=0; i < ndtypes; i++) {
+        PyTuple_SetItem(t_dtypes, i, (PyObject *)op_dtype);
+    }
+    PyObject *loops = ufunc->_loops;
+    Py_ssize_t length = PyList_Size(loops);
+    for (Py_ssize_t i = 0; i < length; i++) {
+        PyObject *item = PyList_GetItem(loops, i);
+        PyObject *cur_DType_tuple = PyTuple_GetItem(item, 0);
+        int cmp = PyObject_RichCompareBool(cur_DType_tuple,
+                                           t_dtypes, Py_EQ);
+        if (cmp < 0) {
+            Py_DECREF(t_dtypes);
+            return NULL;
+        }
+        if (cmp == 0) {
+            continue;
+        }
+        /* Got the match */
+        Py_DECREF(t_dtypes);
+        return PyTuple_GetItem(item, 1);
+    }
+    Py_DECREF(t_dtypes);
+    Py_RETURN_NONE;
+}

--- a/numpy/core/src/umath/dispatching.c
+++ b/numpy/core/src/umath/dispatching.c
@@ -914,8 +914,8 @@ promote_and_get_ufuncimpl(PyUFuncObject *ufunc,
     int nin = ufunc->nin, nargs = ufunc->nargs;
 
     /*
-     * Get the actual DTypes we operate with by mixing the operand array
-     * ones with the passed signature.
+     * Get the actual DTypes we operate with by setting op_dtypes[i] from
+     * signature[i].
      */
     for (int i = 0; i < nargs; i++) {
         if (signature[i] != NULL) {

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -541,15 +541,21 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
     }
 }
 
-NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
-@TYPE@_@kind@@isa@_indexed(char const *ip1, npy_intp const *indx, char *value, 
-                      npy_intp const *dimensions, npy_intp const *steps) {
+NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ int
+@TYPE@_@kind@@isa@_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
     npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
+    @type@ *indexed;
     for(i = 0; i < n; i++, indx += is2, value += os1) {
-        @type@ op1 = *(@type@ *)(ip1 + is1 * indx[0]) +  value[0];
+        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+        indexed[0] = indexed[0] @OP@ *(@type@ *)value;
     }
+    return 0;
 }
 
 #endif
@@ -1546,6 +1552,23 @@ LONGDOUBLE_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps
         }
     }
 }
+
+NPY_NO_EXPORT void
+LONGDOUBLE_@kind@_indexed(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    npy_longdouble *indexed;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        indexed = (npy_longdouble *)(ip1 + is1 * indx[0]);
+        indexed[0] = indexed[0] @OP@ *(npy_longdouble *)value;
+    }
+}
+
 /**end repeat**/
 
 /**begin repeat
@@ -1650,6 +1673,24 @@ HALF_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void
             *((npy_half *)op1) = npy_float_to_half(in1 @OP@ in2);
         }
     }
+}
+
+NPY_NO_EXPORT int
+HALF_@kind@_indexed(void *NPY_UNUSED(context), char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    npy_half *indexed;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        indexed = (npy_half *)(ip1 + is1 * indx[0]);
+        const float v = npy_half_to_float(*(npy_half *)value);
+        indexed[0] = npy_float_to_half(npy_half_to_float(indexed[0]) @OP@ v);
+    }
+    return 0; 
 }
 /**end repeat**/
 

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -557,7 +557,7 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ int
     @type@ *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
-        indexed[0] = indexed[0] @OP@ *(@type@ *)value;
+        *indexed = *indexed @OP@ *(@type@ *)value;
     }
     return 0;
 }
@@ -1436,7 +1436,7 @@ NPY_NO_EXPORT int
     @type@ *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
-        indexed[0] = npy_floor_divide@c@(indexed[0], *(@type@ *)value);
+        *indexed = npy_floor_divide@c@(*indexed, *(@type@ *)value);
     }
     return 0;
 }
@@ -1590,7 +1590,7 @@ LONGDOUBLE_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     npy_longdouble *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (npy_longdouble *)(ip1 + is1 * *(npy_intp *)indx);
-        indexed[0] = indexed[0] @OP@ *(npy_longdouble *)value;
+        *indexed = *indexed @OP@ *(npy_longdouble *)value;
     }
     return 0;
 }
@@ -1714,7 +1714,7 @@ HALF_@kind@_indexed(void *NPY_UNUSED(context), char **args, npy_intp const *dime
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (npy_half *)(ip1 + is1 * *(npy_intp *)indx);
         const float v = npy_half_to_float(*(npy_half *)value);
-        indexed[0] = npy_float_to_half(npy_half_to_float(indexed[0]) @OP@ v);
+        *indexed = npy_float_to_half(npy_half_to_float(*indexed) @OP@ v);
     }
     return 0; 
 }
@@ -1869,8 +1869,8 @@ HALF_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (npy_half *)(ip1 + is1 * *(npy_intp *)indx);
         float v = npy_half_to_float(*(npy_half *)value);
-        float div = npy_floor_dividef(npy_half_to_float(indexed[0]), v);
-        indexed[0] = npy_float_to_half(div);
+        float div = npy_floor_dividef(npy_half_to_float(*indexed), v);
+        *indexed = npy_float_to_half(div);
     }
     return 0;
 }

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -540,6 +540,18 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
         BINARY_LOOP_FAST(@type@, @type@, *out = in1 @OP@ in2);
     }
 }
+
+NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
+@TYPE@_@kind@@isa@_indexed(char const *ip1, npy_intp const *indx, char *value, 
+                      npy_intp const *dimensions, npy_intp const *steps) {
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        @type@ op1 = *(@type@ *)(ip1 + is1 * indx[0]) +  value[0];
+    }
+}
+
 #endif
 
 /**end repeat2**/

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -460,6 +460,7 @@ BOOL_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void
  */
 
 #define @TYPE@_floor_divide @TYPE@_divide
+#define @TYPE@_floor_divide_indexed @TYPE@_divide_indexed
 #define @TYPE@_fmax @TYPE@_maximum
 #define @TYPE@_fmin @TYPE@_minimum
 
@@ -531,7 +532,8 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
 
 #if @CHK@
 NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
-@TYPE@_@kind@@isa@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+@TYPE@_@kind@@isa@(char **args, npy_intp const *dimensions,
+                   npy_intp const *steps, void *NPY_UNUSED(func))
 {
     if (IS_BINARY_REDUCE) {
         BINARY_REDUCE_LOOP_FAST(@type@, io1 @OP@= in2);
@@ -542,17 +544,19 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ void
 }
 
 NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ int
-@TYPE@_@kind@@isa@_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
+@TYPE@_@kind@@isa@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
+                           char * const*args, npy_intp const *dimensions,
+                           npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
-        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
+        indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
         indexed[0] = indexed[0] @OP@ *(@type@ *)value;
     }
     return 0;
@@ -1418,6 +1422,25 @@ NPY_NO_EXPORT void
     }
 }
 
+NPY_NO_EXPORT int
+@TYPE@_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
+         char **args, npy_intp const *dimensions, npy_intp const *steps,
+         void *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    char *indx = args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    @type@ *indexed;
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
+        indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
+        indexed[0] = npy_floor_divide@c@(indexed[0], *(@type@ *)value);
+    }
+    return 0;
+}
+
 NPY_NO_EXPORT void
 @TYPE@_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
@@ -1553,20 +1576,23 @@ LONGDOUBLE_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps
     }
 }
 
-NPY_NO_EXPORT void
-LONGDOUBLE_@kind@_indexed(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
+NPY_NO_EXPORT int
+LONGDOUBLE_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
+         char **args, npy_intp const *dimensions, npy_intp const *steps,
+         void *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     npy_longdouble *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
-        indexed = (npy_longdouble *)(ip1 + is1 * indx[0]);
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
+        indexed = (npy_longdouble *)(ip1 + is1 * *(npy_intp *)indx);
         indexed[0] = indexed[0] @OP@ *(npy_longdouble *)value;
     }
+    return 0;
 }
 
 /**end repeat**/
@@ -1679,14 +1705,14 @@ NPY_NO_EXPORT int
 HALF_@kind@_indexed(void *NPY_UNUSED(context), char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     npy_half *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
-        indexed = (npy_half *)(ip1 + is1 * indx[0]);
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
+        indexed = (npy_half *)(ip1 + is1 * *(npy_intp *)indx);
         const float v = npy_half_to_float(*(npy_half *)value);
         indexed[0] = npy_float_to_half(npy_half_to_float(indexed[0]) @OP@ v);
     }
@@ -1826,6 +1852,27 @@ HALF_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps
         div = npy_floor_dividef(fh1, fh2);
         *((npy_half *)op1) = npy_float_to_half(div);
     }
+}
+
+NPY_NO_EXPORT int
+HALF_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context),
+         char **args, npy_intp const *dimensions, npy_intp const *steps,
+         void *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    char *indx = args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    npy_half *indexed;
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
+        indexed = (npy_half *)(ip1 + is1 * *(npy_intp *)indx);
+        float v = npy_half_to_float(*(npy_half *)value);
+        float div = npy_floor_dividef(npy_half_to_float(indexed[0]), v);
+        indexed[0] = npy_float_to_half(div);
+    }
+    return 0;
 }
 
 NPY_NO_EXPORT void

--- a/numpy/core/src/umath/loops.c.src
+++ b/numpy/core/src/umath/loops.c.src
@@ -547,7 +547,7 @@ NPY_NO_EXPORT NPY_GCC_OPT_3 @ATTR@ int
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
@@ -1559,7 +1559,7 @@ LONGDOUBLE_@kind@_indexed(char **args, npy_intp const *dimensions, npy_intp cons
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     npy_longdouble *indexed;
@@ -1681,7 +1681,7 @@ HALF_@kind@_indexed(void *NPY_UNUSED(context), char **args, npy_intp const *dime
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     npy_half *indexed;

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -33,6 +33,9 @@
 // #define BOOL_fmax BOOL_maximum
 // #define BOOL_fmin BOOL_minimum
 
+typedef struct PyArrayMethod_Context_tag PyArrayMethod_Context;
+typedef struct NpyAuxData_tag NpyAuxData;
+
 #ifndef NPY_DISABLE_OPTIMIZATION
     #include "loops_comparison.dispatch.h"
 #endif
@@ -81,6 +84,11 @@ BOOL_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void
  */
 NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_divide,
     (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func)))
+
+NPY_NO_EXPORT int
+@TYPE@_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func));
+
+/**end repeat3**/
 /**end repeat**/
 
 #ifndef NPY_DISABLE_OPTIMIZATION
@@ -162,6 +170,9 @@ NPY_NO_EXPORT void
  */
 NPY_NO_EXPORT void
 @S@@TYPE@_@kind@@isa@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT int
+@S@@TYPE@_@kind@@isa@_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func));
 
 /**end repeat3**/
 
@@ -285,10 +296,13 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@,
 /**begin repeat1
  * Arithmetic
  * # kind = add, subtract, multiply, divide#
- * # OP = +, -, *, /#
  */
 NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@,
     (char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func)))
+
+NPY_NO_EXPORT int
+@TYPE@_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func));
+
 /**end repeat1**/
 /**end repeat**/
 
@@ -424,6 +438,11 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@, (
  */
 NPY_NO_EXPORT void
 @TYPE@_@kind@(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT int
+@TYPE@_@kind@_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func));
+
+/**end repeat1**/
 /**end repeat1**/
 
 /**begin repeat1

--- a/numpy/core/src/umath/loops.h.src
+++ b/numpy/core/src/umath/loops.h.src
@@ -134,6 +134,7 @@ NPY_CPU_DISPATCH_DECLARE(NPY_NO_EXPORT void @TYPE@_@kind@,
  */
 
 #define @S@@TYPE@_floor_divide @S@@TYPE@_divide
+#define @S@@TYPE@_floor_divide_indexed @S@@TYPE@_divide_indexed
 #define @S@@TYPE@_fmax @S@@TYPE@_maximum
 #define @S@@TYPE@_fmin @S@@TYPE@_minimum
 
@@ -490,6 +491,9 @@ NPY_NO_EXPORT void
 
 NPY_NO_EXPORT void
 @TYPE@_floor_divide(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));
+
+NPY_NO_EXPORT int
+@TYPE@_floor_divide_indexed(PyArrayMethod_Context *NPY_UNUSED(context), char *const *args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func));
 
 NPY_NO_EXPORT void
 @TYPE@_remainder(char **args, npy_intp const *dimensions, npy_intp const *steps, void *NPY_UNUSED(func));

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -546,6 +546,18 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
         }
     }
 }
+
+NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
+(char const *ip1, npy_intp const *indx, char *value, 
+                      npy_intp const *dimensions, npy_intp const *steps) {
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        @type@ op1 = *(@type@ *)(ip1 + is1 * indx[0]) +  value[0];
+    }
+}
+
 /**end repeat1**/
 /**end repeat**/
 

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -553,11 +553,11 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (@type@ *)(ip1 + is1 * indx[0]);
         indexed[0] = indexed[0] @OP@ *(@type@ *)value;
     }

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -547,15 +547,21 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@)
     }
 }
 
-NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
-(char const *ip1, npy_intp const *indx, char *value, 
-                      npy_intp const *dimensions, npy_intp const *steps) {
+NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
+(PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
     npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
+    @type@ *indexed;
     for(i = 0; i < n; i++, indx += is2, value += os1) {
-        @type@ op1 = *(@type@ *)(ip1 + is1 * indx[0]) +  value[0];
+        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+        indexed[0] = indexed[0] @OP@ *(@type@ *)value;
     }
+    return 0;
 }
 
 /**end repeat1**/

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -551,15 +551,15 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
-        indexed = (@type@ *)(ip1 + is1 * indx[0]);
-        indexed[0] = indexed[0] @OP@ *(@type@ *)value;
+        indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
+        *indexed = *indexed @OP@ *(@type@ *)value;
     }
     return 0;
 }

--- a/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithm_fp.dispatch.c.src
@@ -553,7 +553,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_@kind@_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -402,7 +402,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
@@ -488,7 +488,7 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -395,6 +395,24 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)
         }
     }
 }
+
+NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
+(PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    @type@ *indexed;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+        indexed[0] = floor_div_@TYPE@(indexed[0], *(@type@ *)value);
+    }
+    return 0;
+}
+
 /**end repeat**/
 
 /**begin repeat
@@ -463,4 +481,28 @@ NPY_NO_EXPORT void NPY_CPU_DISPATCH_CURFX(@TYPE@_divide)
         }
     }
 }
+
+NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
+(PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
+{
+    char *ip1 = args[0];
+    npy_intp *indx = (npy_intp *)args[1];
+    char *value = args[2];
+    npy_intp is1 = steps[0], is2 = steps[1], os1 = steps[2];
+    npy_intp n = dimensions[0];
+    npy_intp i;
+    @type@ *indexed;
+    for(i = 0; i < n; i++, indx += is2, value += os1) {
+        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+        @type@ in2 = *(@type@ *)value;
+        if (NPY_UNLIKELY(in2 == 0)) {
+            npy_set_floatstatus_divbyzero();
+            indexed[0] = 0;
+        } else {
+            indexed[0] = indexed[0] / in2;
+        }
+    }
+    return 0;
+}
+
 /**end repeat**/

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -402,11 +402,11 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (@type@ *)(ip1 + is1 * indx[0]);
         indexed[0] = floor_div_@TYPE@(indexed[0], *(@type@ *)value);
     }
@@ -488,11 +488,11 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
     char *ip1 = args[0];
     npy_intp *indx = (npy_intp *)args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], is2 = steps[1] / sizeof(npy_intp), os1 = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
-    for(i = 0; i < n; i++, indx += is2, value += os1) {
+    for(i = 0; i < n; i++, indx += isindex, value += isb) {
         indexed = (@type@ *)(ip1 + is1 * indx[0]);
         @type@ in2 = *(@type@ *)value;
         if (NPY_UNLIKELY(in2 == 0)) {

--- a/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
+++ b/numpy/core/src/umath/loops_arithmetic.dispatch.c.src
@@ -400,15 +400,15 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
-        indexed = (@type@ *)(ip1 + is1 * indx[0]);
-        indexed[0] = floor_div_@TYPE@(indexed[0], *(@type@ *)value);
+        indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
+        *indexed = floor_div_@TYPE@(*indexed, *(@type@ *)value);
     }
     return 0;
 }
@@ -486,20 +486,20 @@ NPY_NO_EXPORT int NPY_CPU_DISPATCH_CURFX(@TYPE@_divide_indexed)
 (PyArrayMethod_Context *NPY_UNUSED(context), char * const*args, npy_intp const *dimensions, npy_intp const *steps, NpyAuxData *NPY_UNUSED(func))
 {
     char *ip1 = args[0];
-    npy_intp *indx = (npy_intp *)args[1];
+    char *indx = args[1];
     char *value = args[2];
-    npy_intp is1 = steps[0], isindex = steps[1] / sizeof(npy_intp), isb = steps[2];
+    npy_intp is1 = steps[0], isindex = steps[1], isb = steps[2];
     npy_intp n = dimensions[0];
     npy_intp i;
     @type@ *indexed;
     for(i = 0; i < n; i++, indx += isindex, value += isb) {
-        indexed = (@type@ *)(ip1 + is1 * indx[0]);
+        indexed = (@type@ *)(ip1 + is1 * *(npy_intp *)indx);
         @type@ in2 = *(@type@ *)value;
         if (NPY_UNLIKELY(in2 == 0)) {
             npy_set_floatstatus_divbyzero();
-            indexed[0] = 0;
+            *indexed = 0;
         } else {
-            indexed[0] = indexed[0] / in2;
+            *indexed = *indexed / in2;
         }
     }
     return 0;

--- a/numpy/core/src/umath/scalarmath.c.src
+++ b/numpy/core/src/umath/scalarmath.c.src
@@ -453,7 +453,7 @@ static inline int
 @name@_ctype_divide(@type@ a, @type@ b, @type@ *out)
 {
     char *args[3] = {(char *)&a, (char *)&b, (char *)out};
-    npy_intp steps[3];
+    npy_intp steps[3] = {0, 0, 0};
     npy_intp size = 1;
     @TYPE@_divide(args, &size, steps, NULL);
     return 0;

--- a/numpy/core/src/umath/ufunc_object.c
+++ b/numpy/core/src/umath/ufunc_object.c
@@ -5906,10 +5906,6 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
     int buffersize=0, errormask = 0;
     int res;
     char *args[3];
-    const char * ufunc_name = ufunc_get_name_cstr((PyUFuncObject *)context->caller);
-    if (_get_bufsize_errmask(NULL, ufunc_name, &buffersize, &errormask) < 0) {
-        return -1;
-    }
     npy_intp dimensions = iter->size;
     npy_intp steps[3];
     args[0] = (char *) iter->baseoffset;
@@ -5929,6 +5925,12 @@ trivial_at_loop(PyArrayMethodObject *ufuncimpl, NPY_ARRAYMETHOD_FLAGS flags,
     }
 
     if (res == 0 && !(flags & NPY_METH_NO_FLOATINGPOINT_ERRORS)) {
+        const char * ufunc_name = 
+                        ufunc_get_name_cstr((PyUFuncObject *)context->caller);
+        if (_get_bufsize_errmask(NULL, ufunc_name,
+                                 &buffersize, &errormask) < 0) {
+            return -1;
+        }
         res = _check_ufunc_fperr(errormask, NULL, ufunc_name);
     }
     return res;

--- a/numpy/core/tests/test_ufunc.py
+++ b/numpy/core/tests/test_ufunc.py
@@ -1988,12 +1988,14 @@ class TestUfunc:
             np.add.at(a, [2, 5, 3], [[1, 2], 1])
     
     # ufuncs with indexed loops for perfomance in ufunc.at
-    indexed_ufuncs = [np.add, np.subtract, np.multiply, np.floor_divide, np.divide]
+    indexed_ufuncs = [np.add, np.subtract, np.multiply,
+                      np.floor_divide, np.divide]
+
     @pytest.mark.parametrize(
                 "typecode", np.typecodes['AllInteger'] + np.typecodes['Float'])
     @pytest.mark.parametrize("ufunc", indexed_ufuncs)
     def test_ufunc_at_inner_loops(self, typecode, ufunc):
-        if ufunc is np.divide and typecode in  np.typecodes['AllInteger']:
+        if ufunc is np.divide and typecode in np.typecodes['AllInteger']:
             # Avoid divide-by-zero and inf for integer divide
             a = np.ones(100, dtype=typecode)
             indx = np.random.randint(100, size=30, dtype=np.intp)
@@ -2009,7 +2011,7 @@ class TestUfunc:
             ufunc.at(a, indx, vals)
         with warnings.catch_warnings(record=True) as w_loop:
             warnings.simplefilter('always')
-            for i,v in zip(indx, vals):
+            for i, v in zip(indx, vals):
                 # Make sure all the work happens inside the ufunc
                 # in order to duplicate error/warning handling
                 ufunc(atag[i], v, out=atag[i:i+1], casting="unsafe")


### PR DESCRIPTION
- Create inner loop functions where the second argument is an index to use for the first argument
- Add a slot for these loops to `ArrayMethodObject`
- Add code to parse a new kwarg `"indexed"` to the `Ufunc` class in `numpy/core/code_generators/generate_umath.py` which will generate C code to add the loops. It uses `get_info_no_cast` to find the correct `ArrayMethodObject` in the `ufunc._loop` info list.
- thread a new `try_trivial_at_loop` into the logic of `ufunc_at` to call the new loops.

The good news is that `ufunc_at` can be up to 6.5x faster (via the benchmark added in numpy/numpy#22889). The bad news is that other benchmarks got slower. I am not sure why. Maybe the added field made the ufunc too big?

<details><summary>Benchmarks vs. main</summary>

```
       before           after         ratio
     [c662a712]       [eb21b250]
     <main>           <indexed-loopos>
+      68.0±0.4μs          126±7μs     1.85  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '<')
+      66.6±0.6μs        117±0.5μs     1.75  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '<=')
+       134±0.5μs        234±0.7μs     1.75  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '<=')
+        67.8±1μs        118±0.5μs     1.74  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '<=')
+      66.7±0.7μs          111±1μs     1.66  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '>')
+      33.5±0.4μs         54.1±1μs     1.61  bench_strings.StringComparisons.time_compare_identical(10000, 'U', False, '<')
+       133±0.7μs          215±7μs     1.61  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '>')
+      34.1±0.2μs         54.6±1μs     1.60  bench_strings.StringComparisons.time_compare_identical(10000, 'U', False, '>')
+         131±3μs        210±0.8μs     1.60  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '<')
+      66.2±0.3μs        106±0.1μs     1.59  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '<')
+      68.2±0.6μs          108±3μs     1.59  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '>')
+     1.18±0.01μs       1.71±0.1μs     1.45  bench_strings.StringComparisons.time_compare_identical(100, 'U', True, '<')
+         532±4μs         720±10μs     1.35  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'rad2deg'>, 1, 1, 'e')
+         532±2μs         716±50μs     1.35  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 2, 'e')
+        1.96±0ms       2.64±0.6ms     1.35  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp'>, 2, 4, 'f')
+     4.58±0.03μs      6.16±0.01μs     1.34  bench_function_base.Sort.time_sort('merge', 'int32', ('ordered',))
+        26.1±2μs       35.0±0.8μs     1.34  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 1000))
+         516±1μs         689±50μs     1.34  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'degrees'>, 4, 4, 'e')
+     4.57±0.02μs      6.10±0.03μs     1.33  bench_function_base.Sort.time_sort('merge', 'int32', ('uniform',))
+         531±5μs         699±60μs     1.32  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'fabs'>, 4, 4, 'e')
+         680±2ns         891±20ns     1.31  bench_itemselection.PutMask.time_sparse(True, 'int64')
+     1.21±0.01μs      1.58±0.03μs     1.31  bench_strings.StringComparisons.time_compare_identical(100, 'U', True, '>')
+         530±2μs         692±40μs     1.31  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 1, 4, 'e')
+        663±20ns          867±2ns     1.31  bench_itemselection.PutMask.time_sparse(True, 'float64')
+         530±2μs         690±10μs     1.30  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'degrees'>, 4, 1, 'e')
+         531±3μs         685±90μs     1.29  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 2, 2, 'e')
+         678±5ns          873±3ns     1.29  bench_itemselection.PutMask.time_sparse(True, 'complex64')
+       551±0.5μs         708±10μs     1.28  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'floor'>, 1, 1, 'e')
+         527±9μs         670±50μs     1.27  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'fabs'>, 1, 2, 'e')
+         535±4μs         674±60μs     1.26  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'degrees'>, 1, 4, 'e')
+         537±4μs         670±10μs     1.25  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'ceil'>, 4, 1, 'e')
+         554±4μs         682±30μs     1.23  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'floor'>, 4, 4, 'e')
+        856±20ns         1.04±0μs     1.22  bench_strings.StringComparisons.time_compare_identical(100, 'U', False, '<')
+         918±8ns         1.12±0μs     1.22  bench_itemselection.PutMask.time_dense(False, 'float16')
+         872±5ns      1.06±0.03μs     1.22  bench_strings.StringComparisons.time_compare_identical(100, 'U', False, '>')
+         660±1μs         800±20μs     1.21  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 4, 1, 'e')
+         660±2μs         800±40μs     1.21  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 2, 2, 'e')
+        91.6±2μs        111±0.1μs     1.21  bench_function_base.Sort.time_argsort('merge', 'uint32', ('sorted_block', 10))
+         661±3μs         798±10μs     1.21  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 1, 2, 'e')
+        52.7±5μs       63.4±0.9μs     1.20  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 100))
+      76.5±0.2μs       92.0±0.6μs     1.20  bench_core.UnpackBits.time_unpackbits_axis1
+         917±3ns         1.10±0μs     1.20  bench_itemselection.PutMask.time_dense(False, 'int16')
+      39.4±0.7μs       47.3±0.1μs     1.20  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 2, 1, 'e')
+         666±5μs         798±10μs     1.20  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 1, 4, 'e')
+      28.5±0.2μs         34.1±2μs     1.19  bench_strings.StringComparisons.time_compare_identical(10000, 'S', True, '<')
+         660±1μs         788±30μs     1.19  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 4, 2, 'e')
+         662±3μs         788±30μs     1.19  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 4, 4, 'e')
+      40.3±0.1μs      47.6±0.07μs     1.18  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 4, 1, 'e')
+     4.41±0.01μs      5.21±0.05μs     1.18  bench_core.UnpackBits.time_unpackbits
+     10.7±0.07μs       12.6±0.3μs     1.18  bench_function_base.Sort.time_argsort('merge', 'float32', ('reversed',))
+        650±10μs         764±50μs     1.18  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 1, 1, 'e')
+     40.3±0.04μs       47.2±0.2μs     1.17  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 1, 2, 'e')
+     3.04±0.02μs      3.55±0.01μs     1.17  bench_itemselection.PutMask.time_dense(True, 'complex256')
+      39.5±0.5μs       46.0±0.7μs     1.17  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 1, 1, 'e')
+        2.62±0ms      3.03±0.06ms     1.16  bench_lib.Pad.time_pad((256, 128, 1), 8, 'linear_ramp')
+      41.3±0.2μs       47.7±0.2μs     1.15  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 4, 4, 'e')
+         660±4μs         762±40μs     1.15  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'log2'>, 2, 4, 'e')
+      40.6±0.2μs         46.6±1μs     1.15  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 4, 2, 'e')
+      40.6±0.3μs       46.4±0.9μs     1.14  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 2, 2, 'e')
+        50.1±1μs       57.2±0.2μs     1.14  bench_function_base.Sort.time_argsort('quick', 'int32', ('ordered',))
+      41.2±0.6μs       46.9±0.7μs     1.14  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 1, 4, 'e')
+        73.7±2μs       83.3±0.1μs     1.13  bench_reduce.AddReduceSeparate.time_reduce(0, 'float32')
+      41.5±0.3μs       46.8±0.7μs     1.13  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'positive'>, 2, 4, 'e')
+         797±6ns          896±9ns     1.12  bench_itemselection.PutMask.time_sparse(False, 'int16')
+      32.2±0.4μs       36.2±0.9μs     1.12  bench_strings.StringComparisons.time_compare_different((1000, 20), 'S', False, '<')
+        82.7±2μs         92.8±2μs     1.12  bench_function_base.Sort.time_sort('merge', 'int32', ('sorted_block', 10))
+         208±4μs          233±2μs     1.12  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 1, 1, 'f')
+       210±0.5μs          235±4μs     1.12  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 2, 4, 'f')
+         263±9μs          293±5μs     1.12  bench_function_base.Sort.time_sort('quick', 'int32', ('sorted_block', 100))
+     4.50±0.09μs       5.02±0.1μs     1.11  bench_indexing.ScalarIndexing.time_assign(0)
+       210±0.4μs        234±0.8μs     1.11  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 4, 1, 'f')
+         110±3μs          122±2μs     1.11  bench_function_base.Sort.time_argsort('merge', 'float32', ('sorted_block', 10))
+         214±2μs          237±2μs     1.11  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 4, 4, 'f')
+         210±2μs          233±3μs     1.11  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 2, 1, 'f')
+       212±0.5μs          235±1μs     1.11  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'exp2'>, 2, 2, 'f')
+         797±3ns          881±2ns     1.11  bench_itemselection.PutMask.time_dense(True, 'int64')
+      23.5±0.1μs       26.0±0.6μs     1.11  bench_function_base.Sort.time_argsort('heap', 'int32', ('uniform',))
+         795±6ns          877±3ns     1.10  bench_itemselection.PutMask.time_sparse(False, 'float16')
+      16.8±0.1μs      18.5±0.06μs     1.10  bench_ufunc.CustomInplace.time_float_add
+      56.4±0.4μs       62.1±0.6μs     1.10  bench_function_base.Sort.time_argsort('quick', 
-         285±1μs          257±1μs     0.90  bench_function_base.Sort.time_sort('quick', 'int16', ('sorted_block', 100))
-      48.2±0.3μs       43.5±0.3μs     0.90  bench_function_base.Sort.time_argsort('quick', 'int16', ('uniform',))
-       339±0.8μs          306±1μs     0.90  bench_function_base.Sort.time_sort('quick', 'int16', ('random',))
-     3.21±0.01μs      2.90±0.07μs     0.90  bench_itemselection.Take.time_contiguous((1000, 2), 'clip', 'longfloat')
-        706±40μs          637±3μs     0.90  bench_random.Random.time_rng('poisson 10')
-         388±6μs          350±3μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'logical_not'>, 1, 1, 'e')
-        76.5±1μs       69.0±0.7μs     0.90  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'S', True, '<=')
-     20.2±0.08μs      18.2±0.06μs     0.90  bench_strings.StringComparisons.time_compare_identical(10000, 'S', False, '<=')
-         512±2μs          462±9μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 4, 2, 'e')
-         517±2μs          466±9μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 2, 4, 'e')
-        31.7±1μs       28.6±0.3μs     0.90  bench_core.Core.time_array_float_l1000_dtype
-      9.44±0.6ms      8.49±0.07ms     0.90  bench_core.CorrConv.time_correlate(100000, 1000, 'full')
-      38.4±0.3μs       34.5±0.1μs     0.90  bench_strings.StringComparisons.time_compare_identical(10000, 'S', True, '<=')
-         511±4μs          460±8μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 1, 4, 'e')
-        38.3±1μs       34.5±0.3μs     0.90  bench_strings.StringComparisons.time_compare_identical(10000, 'S', True, '>=')
-      9.33±0.6ms      8.39±0.05ms     0.90  bench_core.CorrConv.time_correlate(100000, 1000, 'valid')
-     1.35±0.01μs      1.22±0.03μs     0.90  bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'float64')
-         510±3μs         458±10μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 2, 2, 'e')
-      57.2±0.2μs       51.4±0.2μs     0.90  bench_function_base.Sort.time_sort('quick', 'float64', ('ordered',))
-     1.35±0.01μs      1.21±0.01μs     0.90  bench_itemselection.Take.time_contiguous((1000, 2), 'clip', 'float32')
-         511±3μs          458±8μs     0.90  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 1, 1, 'e')
-         445±2μs        400±0.8μs     0.90  bench_function_base.Sort.time_sort('heap', 'float64', ('ordered',))
-        416±20ns          373±2ns     0.90  bench_scalar.ScalarMath.time_abs('float32')
-      3.42±0.2μs      3.07±0.02μs     0.90  bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'complex256')
-      69.2±0.7μs       62.0±0.7μs     0.90  bench_strings.StringComparisons.time_compare_different((1000, 20), 'S', True, '<=')
-         370±6μs          331±8μs     0.90  bench_linalg.Eindot.time_einsum_i_ij_j
-        889±20ns          795±8ns     0.90  bench_itemselection.PutMask.time_sparse(False, 'float64')
-         371±3μs          332±2μs     0.90  bench_function_base.Sort.time_sort('merge', 'uint32', ('random',))
-         514±4μs          459±9μs     0.89  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'square'>, 4, 4, 'e')
-      18.5±0.1μs       16.5±0.2μs     0.89  bench_strings.StringComparisons.time_compare_different(10000, 'S', False, '<=')
-     1.13±0.01μs         1.01±0μs     0.89  bench_itemselection.Take.time_contiguous((1000, 1), 'wrap', 'float32')
-         905±1ns         808±10ns     0.89  bench_itemselection.PutMask.time_sparse(False, 'int64')
-      4.73±0.4ms      4.22±0.04ms     0.89  bench_ufunc.UFunc.time_ufunc_types('exp')
-      5.90±0.2μs      5.25±0.02μs     0.89  bench_linalg.Linalg.time_op('norm', 'int32')
-        99.4±2μs       88.3±0.4μs     0.89  bench_function_base.Bincount.time_bincount
-       186±0.8μs        165±0.7μs     0.89  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 2, 4, 'e')
-     2.10±0.04μs         1.86±0μs     0.89  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'float64')
-       198±0.3ms        176±0.4ms     0.89  bench_function_base.Histogram2D.time_fine_binning
-     1.97±0.01μs      1.74±0.01μs     0.89  bench_core.CountNonzero.time_count_nonzero(3, 100, <class 'str'>)
-       111±0.4μs       97.9±0.3μs     0.89  bench_function_base.Sort.time_sort('merge', 'float64', ('sorted_block', 10))
-         183±3μs          162±3μs     0.88  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 4, 4, 'e')
-        606±20μs          536±3μs     0.88  bench_core.CountNonzero.time_count_nonzero_axis(2, 1000000, <class 'numpy.int16'>)
-       395±0.6μs          349±2μs     0.88  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'logical_not'>, 4, 1, 'e')
-        528±20ns          467±9ns     0.88  bench_scalar.ScalarMath.time_addition('float16')
-      24.5±0.9μs       21.6±0.3μs     0.88  bench_function_base.Sort.time_sort('merge', 'uint32', ('sorted_block', 1000))
-      54.1±0.1μs       47.7±0.4μs     0.88  bench_core.CountNonzero.time_count_nonzero(1, 10000, <class 'str'>)
-     1.37±0.02μs      1.21±0.03μs     0.88  bench_itemselection.Take.time_contiguous((1000, 1), 'clip', 'int64')
-     1.59±0.01μs      1.40±0.01μs     0.88  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'wrap', 'int32')
-     1.37±0.02μs      1.20±0.01μs     0.88  bench_itemselection.Take.time_contiguous((1000, 2), 'clip', 'int32')
-      46.8±0.7μs       41.1±0.7μs     0.88  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 2, 4, 'e')
-       186±0.8μs        163±0.5μs     0.88  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 2, 2, 'e')
-     45.3±0.09μs       39.7±0.6μs     0.88  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 2, 1, 'e')
-       186±0.8μs          163±1μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 4, 2, 'e')
-         904±3ns          791±4ns     0.87  bench_itemselection.PutMask.time_dense(True, 'int16')
-         904±3ns          790±9ns     0.87  bench_itemselection.PutMask.time_sparse(False, 'int32')
-       108±0.7μs       93.9±0.5μs     0.87  bench_core.CountNonzero.time_count_nonzero(2, 10000, <class 'str'>)
-       185±0.9μs          161±3μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 1, 4, 'e')
-        1.01±0ms         875±40μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'rint'>, 1, 4, 'e')
-     2.15±0.02μs      1.86±0.01μs     0.87  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'int64')
-        620±20μs         539±30μs     0.87  bench_reduce.AddReduceSeparate.time_reduce(0, 'complex128')
-     1.60±0.01μs      1.39±0.01μs     0.87  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'wrap', 'float32')
-        46.8±1μs       40.6±0.7μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 4, 4, 'e')
-         186±1μs          161±3μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 4, 1, 'e')
-     2.14±0.01μs      1.85±0.01μs     0.87  bench_itemselection.Take.time_contiguous((2, 1000, 1), 'clip', 'complex64')
-         185±1μs          160±3μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 1, 1, 'e')
-       385±0.9μs          333±1μs     0.87  bench_function_base.Sort.time_sort('merge', 'int64', ('random',))
-      91.2±0.3μs       78.9±0.6μs     0.87  bench_ufunc_strides.AVX_ldexp.time_ufunc('e', 2)
-      47.2±0.1μs       40.8±0.5μs     0.87  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 1, 4, 'e')
-     1.15±0.01ms          993±6μs     0.87  bench_lib.Nan.time_nanvar(200000, 90.0)
-       185±0.3μs          160±2μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 2, 1, 'e')
-      47.4±0.3μs       40.9±0.2μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 4, 2, 'e')
-         896±3ns          773±4ns     0.86  bench_itemselection.PutMask.time_sparse(False, 'float32')
-     47.0±0.07μs       40.6±0.6μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 1, 4, 'e')
-      47.1±0.1μs       40.6±0.1μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 2, 2, 'e')
-       185±0.3μs          159±3μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sign'>, 1, 2, 'e')
-      34.6±0.6μs      29.7±0.08μs     0.86  bench_function_base.Sort.time_argsort('heap', 'float32', ('uniform',))
-         103±3μs         88.7±2μs     0.86  bench_function_base.Sort.time_sort('quick', 'float32', ('reversed',))
-      47.8±0.2μs       41.1±0.9μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 4, 4, 'e')
-         901±5ns          774±5ns     0.86  bench_itemselection.PutMask.time_dense(True, 'float16')
-       104±0.3μs         89.0±3μs     0.86  bench_function_base.Sort.time_sort('quick', 'float64', ('reversed',))
-      46.7±0.4μs       40.0±0.9μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 2, 2, 'e')
-      47.7±0.2μs       40.9±0.4μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 2, 4, 'e')
-      47.1±0.2μs       40.3±0.5μs     0.86  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 1, 2, 'e')
-       106±0.4μs         91.2±1μs     0.86  bench_function_base.Sort.time_argsort('quick', 'float64', ('reversed',))
-       100.0±1μs       85.5±0.1μs     0.86  bench_function_base.Sort.time_argsort('quick', 'int64', ('reversed',))
-      47.2±0.2μs       40.3±0.6μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 1, 2, 'e')
-     1.16±0.01ms          987±3μs     0.85  bench_lib.Nan.time_nanstd(200000, 90.0)
-        1.02±0ms         862±10μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'rint'>, 1, 2, 'e')
-         907±5ns          770±4ns     0.85  bench_itemselection.PutMask.time_sparse(False, 'complex64')
-      47.4±0.3μs       40.2±0.4μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 4, 2, 'e')
-      47.1±0.1μs       39.8±0.5μs     0.85  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 2, 1, 'e')
-      47.4±0.5μs       39.9±0.5μs     0.84  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 4, 1, 'e')
-      59.3±0.2μs       49.9±0.1μs     0.84  bench_function_base.Sort.time_argsort('quick', 'int16', ('ordered',))
-     26.8±0.08μs       22.5±0.2μs     0.84  bench_function_base.Sort.time_argsort('heap', 'uint32', ('uniform',))
-      47.0±0.2μs         39.5±1μs     0.84  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 1, 1, 'e')
-     1.33±0.01ms      1.12±0.03ms     0.84  bench_linalg.Einsum.time_einsum_noncon_outer(<class 'numpy.float32'>)
-      47.2±0.1μs         39.7±1μs     0.84  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (0), 4, 1, 'e')
-     63.4±0.08μs       53.3±0.1μs     0.84  bench_function_base.Sort.time_argsort('quick', 'float64', ('ordered',))
-      47.0±0.3μs       39.4±0.6μs     0.84  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'conjugate'> (1), 1, 1, 'e')
-     18.5±0.03μs       15.5±0.2μs     0.84  bench_ufunc.CustomInplace.time_double_add
-     8.24±0.03μs       6.90±0.2μs     0.84  bench_function_base.Sort.time_argsort('merge', 'uint32', ('uniform',))
-         116±2μs       96.4±0.3μs     0.83  bench_function_base.Sort.time_argsort('merge', 'int32', ('sorted_block', 10))
-         761±3μs         634±80μs     0.83  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sqrt'>, 1, 1, 'e')
-      47.4±0.1μs       39.4±0.2μs     0.83  bench_function_base.Sort.time_sort('quick', 'int64', ('uniform',))
-         595±9μs          494±3μs     0.83  bench_lib.Nan.time_nanvar(200000, 2.0)
-       101±0.3μs       83.7±0.8μs     0.83  bench_function_base.Sort.time_argsort('merge', 'int64', ('sorted_block', 10))
-         758±1μs         626±80μs     0.83  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sqrt'>, 4, 1, 'e')
-        13.7±1μs       11.2±0.3μs     0.82  bench_function_base.Where.time_2_broadcast
-         609±2μs          498±6μs     0.82  bench_lib.Nan.time_nanstd(200000, 2.0)
-     1.05±0.02μs          856±9ns     0.81  bench_core.CountNonzero.time_count_nonzero(1, 10000, <class 'numpy.int16'>)
-     8.27±0.01μs      6.72±0.02μs     0.81  bench_function_base.Sort.time_argsort('merge', 'uint32', ('ordered',))
-      37.1±0.4μs       30.1±0.2μs     0.81  bench_function_base.Sort.time_argsort('merge', 'int64', ('sorted_block', 1000))
-     1.16±0.01μs         933±20ns     0.81  bench_itemselection.PutMask.time_dense(False, 'int64')
-         489±3μs          393±5μs     0.80  bench_lib.Nan.time_nanstd(200000, 0.1)
-      94.7±0.9μs       76.1±0.3μs     0.80  bench_function_base.Sort.time_sort('merge', 'int64', ('sorted_block', 10))
-      13.3±0.1μs      10.7±0.06μs     0.80  bench_function_base.Where.time_2
-         783±4μs         627±80μs     0.80  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'radians'>, 4, 1, 'e')
-         468±4μs          373±2μs     0.80  bench_lib.Nan.time_nanvar(200000, 0)
-         481±1μs          380±7μs     0.79  bench_lib.Nan.time_nanstd(200000, 0)
-        1.15±0μs          906±6ns     0.79  bench_itemselection.PutMask.time_dense(False, 'complex64')
-        69.6±4μs         54.9±1μs     0.79  bench_function_base.Sort.time_argsort('merge', 'int64', ('sorted_block', 100))
-     8.76±0.04μs       6.89±0.2μs     0.79  bench_function_base.Sort.time_sort('merge', 'uint32', ('reversed',))
-        1.16±0μs          912±4ns     0.79  bench_itemselection.PutMask.time_dense(False, 'float64')
-      94.9±0.6μs         74.3±1μs     0.78  bench_function_base.Sort.time_sort('quick', 'int16', ('reversed',))
-      11.9±0.2μs       9.31±0.2μs     0.78  bench_function_base.Sort.time_sort('merge', 'float64', ('reversed',))
-         488±1μs          380±3μs     0.78  bench_lib.Nan.time_nanvar(200000, 0.1)
-      9.64±0.2μs       7.50±0.1μs     0.78  bench_function_base.Sort.time_sort('merge', 'int64', ('reversed',))
-     1.11±0.01μs         865±10ns     0.78  bench_strings.StringComparisons.time_compare_identical(100, 'U', False, '!=')
-     9.43±0.09μs      7.26±0.03μs     0.77  bench_linalg.Linalg.time_op('norm', 'int64')
-        1.64±0μs         1.25±0μs     0.76  bench_core.CountNonzero.time_count_nonzero(2, 10000, <class 'numpy.int16'>)
-        1.11±0μs          841±2ns     0.76  bench_strings.StringComparisons.time_compare_identical(100, 'U', False, '==')
-        53.9±5μs       40.8±0.8μs     0.76  bench_function_base.Sort.time_sort('quick', 'uint32', ('ordered',))
-         120±1μs         89.9±2μs     0.75  bench_linalg.Einsum.time_einsum_mul(<class 'numpy.float32'>)
-         782±6μs         584±30μs     0.75  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'deg2rad'>, 4, 4, 'e')
-         901±2ns          668±9ns     0.74  bench_itemselection.PutMask.time_sparse(True, 'int16')
-     1.64±0.01μs      1.21±0.01μs     0.74  bench_strings.StringComparisons.time_compare_identical(100, 'U', True, '!=')
-     2.25±0.03μs      1.65±0.01μs     0.73  bench_core.CountNonzero.time_count_nonzero(3, 10000, <class 'numpy.int16'>)
-         902±7ns         659±10ns     0.73  bench_itemselection.PutMask.time_sparse(True, 'float16')
-      1.20±0.1μs         864±20ns     0.72  bench_strings.StringComparisons.time_compare_identical(100, 'U', False, '>=')
-     1.63±0.01μs         1.16±0μs     0.71  bench_strings.StringComparisons.time_compare_identical(100, 'U', True, '>=')
-     6.96±0.07μs      4.83±0.05μs     0.69  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'absolute'>, 1, 1, 'e')
-      58.6±0.2μs       40.1±0.3μs     0.68  bench_core.CountNonzero.time_count_nonzero(1, 1000000, <class 'numpy.int16'>)
-       175±0.4μs        119±0.9μs     0.68  bench_core.CountNonzero.time_count_nonzero(3, 1000000, <class 'numpy.int16'>)
-        751±10μs        511±100μs     0.68  bench_ufunc_strides.Unary.time_ufunc(<ufunc 'sqrt'>, 4, 2, 'e')
-        1.71±0μs         1.16±0μs     0.68  bench_strings.StringComparisons.time_compare_identical(100, 'U', True, '==')
-         135±1μs         91.1±2μs     0.67  bench_function_base.Mean.time_mean_axis(100000)
-       118±0.8μs       79.4±0.5μs     0.67  bench_core.CountNonzero.time_count_nonzero(2, 1000000, <class 'numpy.int16'>)
-       131±0.3μs       86.8±0.6μs     0.66  bench_function_base.Mean.time_mean(100000)
-      46.1±0.8μs      30.2±0.09μs     0.66  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 4, 2, 'e')
-       371±0.5μs          243±6μs     0.65  bench_core.PackBits.time_packbits_axis0(<class 'bool'>)
-      46.9±0.2μs       30.3±0.5μs     0.65  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 1, 4, 'e')
-        46.0±1μs       29.6±0.6μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 4, 1, 'e')
-      47.0±0.3μs       30.2±0.5μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 1, 2, 'e')
-        46.1±1μs       29.7±0.5μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 2, 2, 'e')
-      46.9±0.1μs      30.0±0.07μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 1, 1, 'e')
-      47.1±0.2μs       30.0±0.5μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 2, 4, 'e')
-      47.4±0.2μs       30.2±0.6μs     0.64  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 4, 4, 'e')
-      46.9±0.2μs       29.5±0.6μs     0.63  bench_ufunc_strides.Unary.time_ufunc(<ufunc '_ones_like'>, 2, 1, 'e')
-       111±0.2μs         66.7±1μs     0.60  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '!=')
-         108±2μs       65.0±0.1μs     0.60  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '>=')
-      55.6±0.1μs       32.9±0.2μs     0.59  bench_strings.StringComparisons.time_compare_identical(10000, 'U', False, '!=')
-         217±1μs        128±0.8μs     0.59  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '!=')
-       109±0.4μs      64.3±0.07μs     0.59  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '!=')
-        57.4±3μs       33.6±0.8μs     0.59  bench_strings.StringComparisons.time_compare_identical(10000, 'U', False, '>=')
-         113±6μs       64.2±0.4μs     0.57  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '>=')
-        227±10μs        127±0.3μs     0.56  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '>=')
-     3.41±0.01μs      1.90±0.02μs     0.56  bench_io.Copy.time_cont_assign('float32')
-      61.9±0.2μs       33.6±0.5μs     0.54  bench_strings.StringComparisons.time_compare_identical(10000, 'U', False, '==')
-         123±1μs       65.8±0.3μs     0.54  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', False, '==')
-       244±0.8μs          130±3μs     0.53  bench_strings.StringComparisons.time_compare_identical((1000, 20), 'U', True, '==')
-       123±0.4μs       64.1±0.2μs     0.52  bench_strings.StringComparisons.time_compare_identical(10000, 'U', True, '==')
-     8.93±0.04ms      1.17±0.01ms     0.13  bench_ufunc.At.time_sum_at

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.

```

</details>