### PR TITLE
Fix can-cast logic everywhere for same-value casts (only allow numeric)

### DIFF
--- a/numpy/_core/include/numpy/ndarraytypes.h
+++ b/numpy/_core/include/numpy/ndarraytypes.h
@@ -227,8 +227,15 @@ typedef enum {
         NPY_SAME_KIND_CASTING=3,
         /* Allow any casts */
         NPY_UNSAFE_CASTING=4,
-        /* Allow any casts, check that no values overflow/change */
-        NPY_SAME_VALUE_CASTING=5,
+        /*
+         * Allow any casts, check that no values overflow/change. For users
+         * we only accept same-value casting, but array methods (cast impls)
+         * we need to know if same-value is supported on a same-kind cast.
+         * Safe, equiv, and no-casts are assumed to always be same-value safe.
+         */
+        _NPY_SAME_VALUE_CASTING_FLAG = 8,  // Use one bit to indicate same-value
+        NPY_SAME_VALUE_SAME_KIND_CASTING=(_NPY_SAME_VALUE_CASTING_FLAG | NPY_SAME_KIND_CASTING),
+        NPY_SAME_VALUE_CASTING=(_NPY_SAME_VALUE_CASTING_FLAG | NPY_UNSAFE_CASTING),
 } NPY_CASTING;
 
 typedef enum {

--- a/numpy/_core/src/multiarray/array_method.c
+++ b/numpy/_core/src/multiarray/array_method.c
@@ -192,6 +192,7 @@ validate_spec(PyArrayMethod_Spec *spec)
         case NPY_SAME_KIND_CASTING:
         case NPY_UNSAFE_CASTING:
         case NPY_SAME_VALUE_CASTING:
+        case NPY_SAME_VALUE_SAME_KIND_CASTING:
             break;
         default:
             if (spec->casting != -1) {

--- a/numpy/_core/tests/test_casting_unittests.py
+++ b/numpy/_core/tests/test_casting_unittests.py
@@ -77,8 +77,11 @@ class Casting(enum.IntEnum):
     safe = 2
     same_kind = 3
     unsafe = 4
-    same_value = 5
+    same_value_same_kind = 8 | 3
+    same_value = 8 | 4
 
+
+same_value_dtypes = tuple(type(np.dtype(c)) for c in "bhilqBHILQefdgFDG")
 
 def _get_cancast_table():
     table = textwrap.dedent("""
@@ -119,6 +122,12 @@ def _get_cancast_table():
         cancast[from_dt] = {}
         for to_dt, c in zip(dtypes, row[2::2]):
             cancast[from_dt][to_dt] = convert_cast[c]
+            # Of the types checked, numeric cast support same-value
+            if from_dt in same_value_dtypes and to_dt in same_value_dtypes:
+                if cancast[from_dt][to_dt] == Casting.unsafe:
+                    cancast[from_dt][to_dt] = Casting.same_value
+                if cancast[from_dt][to_dt] == Casting.same_kind:
+                    cancast[from_dt][to_dt] = Casting.same_value_same_kind
 
     return cancast
 


### PR DESCRIPTION
Thought it might be easier to just show this part.  You don't have to like the "flag" design of it.

This makes same-value correct for all casts and `can_cast`.  But of course any place where it is used still needs to promise to tell the cast loop about it, which requires passing in the `context.flags` into `PyArray_GetDTypeTransferFunction` (and set up `context.flags` taking into account casting everywhere).

I am willing to cut corners on that part, but I am not sure which or the feasibility of actually doing it without paying much more in technical debt that we safe now.